### PR TITLE
Fix GPU value not showing properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/build/
 **/.vscode/
+cscope.*
+tags

--- a/src/util/FFstrbuf.h
+++ b/src/util/FFstrbuf.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#define FASTFETCH_STRBUF_DEFAULT_ALLOC 64
+#define FASTFETCH_STRBUF_DEFAULT_ALLOC 128
 
 typedef struct FFstrbuf
 {


### PR DESCRIPTION
This Pull Request just increases `FASTFETCH_STRBUF_DEFAULT_ALLOC` from `64` to `128`.

It also adds `ctags` & `cscope` files to `.gitignore`.