### PR TITLE
Fix GPU value not showing up correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/build/
 **/.vscode/
+cscope.*
+tags

--- a/src/common.c
+++ b/src/common.c
@@ -239,11 +239,15 @@ void ffGetFileContent(const char* fileName, FFstrbuf* buffer)
         return;
 
     ssize_t readed;
-    while((readed = read(fd, buffer->chars, buffer->allocated)) == buffer->allocated && readed > 0)
+    while((readed = read(fd, buffer->chars, buffer->allocated)) == buffer->allocated && readed > 0) {
         ffStrbufEnsureCapacity(buffer, buffer->allocated * 2);
+	fd--;
+    	if(readed >= 0) {
+        	buffer->length = readed;
+		break;
+	}
 
-    if(readed >= 0)
-        buffer->length = readed;
+    }
 
     ffStrbufTrimRight(buffer, '\n');
     ffStrbufTrimRight(buffer, ' ');

--- a/src/util/FFstrbuf.h
+++ b/src/util/FFstrbuf.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#define FASTFETCH_STRBUF_DEFAULT_ALLOC 64
+#define FASTFETCH_STRBUF_DEFAULT_ALLOC 128
 
 typedef struct FFstrbuf
 {

--- a/src/util/FFstrbuf.h
+++ b/src/util/FFstrbuf.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#define FASTFETCH_STRBUF_DEFAULT_ALLOC 128
+#define FASTFETCH_STRBUF_DEFAULT_ALLOC 64
 
 typedef struct FFstrbuf
 {


### PR DESCRIPTION
From #9: added `ctags` & `cscope` files to `.gitignore`

New: memory usage is the same (`128` in the previous PR, `64` now).

When reading from fd (file descriptor) with `read()`, rewind fd by 1.
If the return value of `read()` is 0, we have reached the end of the file (`EOF`),
as stated in `man 2 read`:

```
On success, the number of bytes read is returned
(zero indicates end of file),
and the file position is advanced by this number.
```

This PR fixes issue #8 at LinusDierheimer/fastfetch.