### PR TITLE
Fix Void Linux recognition

### DIFF
--- a/src/common/io.c
+++ b/src/common/io.c
@@ -342,7 +342,27 @@ void ffParsePropFile(const char* fileName, const char* regex, char* buffer)
 
     fclose(file);
     if(line != NULL)
+    { // Strip unescaped quotes
+		int j = 0;
+		for (int i = 0; i < len; i ++)
+		{
+			if (buffer[i] != '"' && buffer[i] != '\\')
+			{ 
+				buffer[j++] = buffer[i];
+			}
+			else if (buffer[i+1] == '"' && buffer[i] == '\\')
+			{ 
+				buffer[j++] = '"';
+			}
+			else if (buffer[i+1] != '"' && buffer[i] == '\\')
+			{ 
+				buffer[j++] = '\\';
+			}
+		}
+		if (j > 0) buffer[j] = 0;
+
         free(line);
+    }
 }
 
 void ffParsePropFileHome(FFinstance* instance, const char* relativeFile, const char* regex, char* buffer)

--- a/src/common/io.c
+++ b/src/common/io.c
@@ -344,7 +344,7 @@ void ffParsePropFile(const char* fileName, const char* regex, char* buffer)
     if(line != NULL)
     { // Strip unescaped quotes
 		int j = 0;
-		for (int i = 0; i < len; i ++)
+		for (int i = 0; i < len; i++)
 		{
 			if (buffer[i] != '"' && buffer[i] != '\\')
 			{ 


### PR DESCRIPTION
Added code to strip unescaped qoutes in ID string. Tested on Void and Manjaro.
![voidlinux](https://user-images.githubusercontent.com/82701459/115617606-df2cb800-a2f1-11eb-8c24-5d9eddee8c1d.png)
