### PR TITLE
Added Package Manager support for Void Linux

### DIFF
--- a/src/modules/packages.c
+++ b/src/modules/packages.c
@@ -14,11 +14,8 @@ static uint32_t get_num_elements(const char* dirname, int type) {
     if(dirp == NULL)
         return 0;
 
-    while((entry = readdir(dirp)) != NULL)
-    {
-        if(entry->d_type == DT_DIR && type == DT_DIR)
-            ++num_elements;
-        else if(entry->d_type == DT_REG && type == DT_REG)
+    while((entry = readdir(dirp)) != NULL){
+        if(entry->d_type == type)
             ++num_elements;
     }
 

--- a/src/modules/packages.c
+++ b/src/modules/packages.c
@@ -5,13 +5,7 @@
 #define FF_PACKAGES_MODULE_NAME "Packages"
 #define FF_PACKAGES_NUM_FORMAT_ARGS 3
 
-enum elementType
-{
-    enumDir = 0,
-    enumFile
-};
-
-static uint32_t get_num_elements(const char* dirname, enum elementType type) {
+static uint32_t get_num_elements(const char* dirname, int type) {
     uint32_t num_elements = 0;
     DIR * dirp;
     struct dirent *entry;
@@ -22,13 +16,13 @@ static uint32_t get_num_elements(const char* dirname, enum elementType type) {
 
     while((entry = readdir(dirp)) != NULL)
     {
-        if(entry->d_type == DT_DIR && type == enumDir)
+        if(entry->d_type == DT_DIR && type == DT_DIR)
             ++num_elements;
-        else if(entry->d_type == DT_REG && type == enumFile)
+        else if(entry->d_type == DT_REG && type == DT_REG)
             ++num_elements;
     }
 
-    if(type == enumDir)
+    if(type == DT_DIR)
         num_elements -= 2; // accounting for . and ..
 
     closedir(dirp);
@@ -38,9 +32,9 @@ static uint32_t get_num_elements(const char* dirname, enum elementType type) {
 
 void ffPrintPackages(FFinstance* instance)
 {
-    uint32_t pacman = get_num_elements("/var/lib/pacman/local", enumDir);
-    uint32_t flatpak = get_num_elements("/var/lib/flatpak/app", enumDir);
-    uint32_t xbps = get_num_elements("/var/db/xbps", enumFile);
+    uint32_t pacman = get_num_elements("/var/lib/pacman/local", DT_DIR);
+    uint32_t flatpak = get_num_elements("/var/lib/flatpak/app", DT_DIR);
+    uint32_t xbps = get_num_elements("/var/db/xbps", DT_REG);
 
     uint32_t all = pacman + flatpak + xbps;
 

--- a/src/modules/packages.c
+++ b/src/modules/packages.c
@@ -3,9 +3,9 @@
 #include <dirent.h>
 
 #define FF_PACKAGES_MODULE_NAME "Packages"
-#define FF_PACKAGES_NUM_FORMAT_ARGS 3
+#define FF_PACKAGES_NUM_FORMAT_ARGS 4
 
-static uint32_t get_num_elements(const char* dirname, int type) {
+static uint32_t get_num_elements(const char* dirname, unsigned char type) {
     uint32_t num_elements = 0;
     DIR * dirp;
     struct dirent *entry;

--- a/src/modules/packages.c
+++ b/src/modules/packages.c
@@ -20,10 +20,11 @@ static uint32_t get_num_elements(const char* dirname, enum elementType type) {
     if(dirp == NULL)
         return 0;
 
-    while((entry = readdir(dirp)) != NULL) {
+    while((entry = readdir(dirp)) != NULL)
+    {
         if(entry->d_type == DT_DIR && type == enumDir)
             ++num_elements;
-        if(entry->d_type == DT_REG && type == enumFile)
+        else if(entry->d_type == DT_REG && type == enumFile)
             ++num_elements;
     }
 

--- a/src/modules/packages.c
+++ b/src/modules/packages.c
@@ -14,7 +14,7 @@ static uint32_t get_num_elements(const char* dirname, int type) {
     if(dirp == NULL)
         return 0;
 
-    while((entry = readdir(dirp)) != NULL){
+    while((entry = readdir(dirp)) != NULL) {
         if(entry->d_type == type)
             ++num_elements;
     }


### PR DESCRIPTION
This adds support for xbps.
I don't know how you feel about the `get_num_dirs` rewrite? A `get_num_files` function would be practically identical.

It outputs the right package number at least - neofetch does not for some reason:
![voidpackages](https://user-images.githubusercontent.com/82701459/116304962-69b66100-a7a3-11eb-95f9-aef25e369679.png)
Let me know what you think.