### PR TITLE
Added branch detection for Manjaro

### DIFF
--- a/src/modules/packages.c
+++ b/src/modules/packages.c
@@ -57,7 +57,7 @@ static void getActiveBranch()
 {
     FILE* file = fopen("/etc/pacman-mirrors.conf", "r");
     if(file == NULL)
-        return; // No file or not Manjaro/based
+        return; // No file or not Manjaro[based]
 
     char* line = NULL;
     size_t len = 0, strip;
@@ -75,10 +75,7 @@ static void getActiveBranch()
 
     fclose(file);
 
-    if(match > 0)
-        printf("[%s]", line);
-    else
-        printf("[stable]"); // defaults to stable
+    match > 0 ? printf("[%s]", line) : printf("[stable]");
 
     if(line != NULL)
         free(line);

--- a/src/modules/packages.c
+++ b/src/modules/packages.c
@@ -53,12 +53,6 @@ static uint32_t getNumStrings(const char* filename, const char* needle)
     return count;
 }
 
-static void getActiveBranchManjaro(FFstrbuf buffer)
-{
-    if(ffParsePropFile("/etc/pacman-mirrors.conf", "Branch = ", &buffer) && buffer.length == 0)
-        ffStrbufSetS(&buffer, "stable");
-}
-
 void ffPrintPackages(FFinstance* instance)
 {
     uint32_t pacman = getNumElements("/var/lib/pacman/local", DT_DIR);
@@ -76,8 +70,9 @@ void ffPrintPackages(FFinstance* instance)
     }
     FFstrbuf manjaroBranch;
     ffStrbufInit(&manjaroBranch);
-    getActiveBranchManjaro(manjaroBranch);
-    ffStrbufRecalculateLength(&manjaroBranch); // needed for later length comparison...
+
+    if(ffParsePropFile("/etc/pacman-mirrors.conf", "Branch =", &manjaroBranch) && manjaroBranch.length == 0)
+        ffStrbufSetS(&manjaroBranch, "stable");
 
     if(instance->config.packagesFormat.length == 0)
     {
@@ -99,6 +94,9 @@ void ffPrintPackages(FFinstance* instance)
             if((all = all - pacman) > 0)
                 printf(", ");
         };
+
+        ffStrbufDestroy(&manjaroBranch);
+
         FF_PRINT_PACKAGE(xbps)
         FF_PRINT_PACKAGE(dpkg)
         FF_PRINT_PACKAGE(flatpak)
@@ -122,5 +120,4 @@ void ffPrintPackages(FFinstance* instance)
             {FF_FORMAT_ARG_TYPE_UINT, &snap}
         });
     }
-    ffStrbufDestroy(&manjaroBranch);
 }


### PR DESCRIPTION
I realize you said it wasn't very useful, which I agree with for Arch, but I think it makes sense on Manjaro.
Arch is set up differently (I think), whereas Manjaro only has one active branch at any time.
![branchdetect](https://user-images.githubusercontent.com/82701459/118359023-bced2980-b581-11eb-990c-5e5213b9b125.png)
Some people do change branches when testing, or if they simply want a file that is available only in the unstable repo.
Certainly very useful for people that don't always remember to go back to stable. :wink: 