### PR TITLE
Sanitize custom Plasma theme name

### DIFF
--- a/src/modules/wmtheme.c
+++ b/src/modules/wmtheme.c
@@ -45,8 +45,16 @@ static void printWMThemeFromConfigFile(FFinstance* instance, const char* configF
         return;
     }
 
-    // Remove Plasma-generated prefix
-    ffStrbufRemoveStrings(&theme, 1, "__aurorae__svg__");
+    // Remove Plasma-generated prefixes
+    uint32_t idx = 0;
+
+    idx = ffStrbufFirstIndexS(&theme, "qml_");
+    if((idx != theme.length))
+        ffStrbufSubstrAfter(&theme, idx + 3);
+
+    idx = ffStrbufFirstIndexS(&theme, "svg__");
+    if((idx != theme.length))
+        ffStrbufSubstrAfter(&theme, idx + 4);
 
     printWMTheme(instance, theme.chars);
     ffStrbufDestroy(&theme);

--- a/src/modules/wmtheme.c
+++ b/src/modules/wmtheme.c
@@ -49,11 +49,11 @@ static void printWMThemeFromConfigFile(FFinstance* instance, const char* configF
     uint32_t idx = 0;
 
     idx = ffStrbufFirstIndexS(&theme, "qml_");
-    if((idx != theme.length))
+    if(idx != theme.length)
         ffStrbufSubstrAfter(&theme, idx + 3);
 
     idx = ffStrbufFirstIndexS(&theme, "svg__");
-    if((idx != theme.length))
+    if(idx != theme.length)
         ffStrbufSubstrAfter(&theme, idx + 4);
 
     printWMTheme(instance, theme.chars);

--- a/src/modules/wmtheme.c
+++ b/src/modules/wmtheme.c
@@ -45,6 +45,9 @@ static void printWMThemeFromConfigFile(FFinstance* instance, const char* configF
         return;
     }
 
+    // Remove Plasma generated garbage
+    ffStrbufRemoveStrings(&theme, 1, "__aurorae__svg__");
+
     printWMTheme(instance, theme.chars);
     ffStrbufDestroy(&theme);
 }

--- a/src/modules/wmtheme.c
+++ b/src/modules/wmtheme.c
@@ -45,7 +45,7 @@ static void printWMThemeFromConfigFile(FFinstance* instance, const char* configF
         return;
     }
 
-    // Remove Plasma generated garbage
+    // Remove Plasma-generated prefix
     ffStrbufRemoveStrings(&theme, 1, "__aurorae__svg__");
 
     printWMTheme(instance, theme.chars);


### PR DESCRIPTION
Plasma prefixes the theme name in `kwinrc` with `"__aurorae__svg__"` for custom themes it seems.

The name shows up as normal in settings:
![plasmatheme](https://user-images.githubusercontent.com/82701459/123504078-64687c00-d657-11eb-98b3-ffe4d2792f3a.png)
Theme desktop entry:
```
[Desktop Entry]
Name=Nord-Aurorae
Comment=Nord-Aurorae
X-KDE-PluginInfo-Author=l4k1
X-KDE-PluginInfo-Email=l4k1987@gmail.com
X-KDE-PluginInfo-Version=1.0
X-KDE-PluginInfo-Name=Nord-Aurorae
X-KDE-PluginInfo-Category=
X-KDE-PluginInfo-Depends=
X-KDE-PluginInfo-License=GPLv3
X-KDE-PluginInfo-EnabledByDefault=true
```
The only place the string appears is in the `kwinrc` file, so I think #67 is valid after all.