### PR TITLE
Fixed Thunar terminal open segfault

### DIFF
--- a/src/common/detectTerminalShell.c
+++ b/src/common/detectTerminalShell.c
@@ -232,7 +232,6 @@ const FFTerminalShellResult* ffDetectTerminalShell(FFinstance* instance)
 
     ffStrbufInit(&result.terminalProcessName);
     ffStrbufInit(&result.terminalExe);
-    result.terminalExeName = result.terminalExe.chars;
 
     ffStrbufInit(&result.userShellExe);
     result.userShellExeName = result.userShellExe.chars;
@@ -241,6 +240,7 @@ const FFTerminalShellResult* ffDetectTerminalShell(FFinstance* instance)
     char ppid[256];
     snprintf(ppid, 255, "%i", getppid());
     getTerminalShell(&result, ppid);
+    result.terminalExeName = result.terminalExe.chars;
 
     getTerminalFromEnv(&result);
     getUserShellFromEnv(&result);

--- a/src/common/detectWMDE.c
+++ b/src/common/detectWMDE.c
@@ -66,6 +66,9 @@ static void getSessionDesktop(FFWMDEResult* result)
 
 static void applyPrettyNameIfWM(FFWMDEResult* result, const char* processName, ProtocolHint* protocolHint)
 {
+    if(processName == NULL || *processName == '\0')
+        return;
+
     if(strcasecmp(processName, "kwin_wayland") == 0)
     {
         ffStrbufSetS(&result->wmPrettyName, "KWin");


### PR DESCRIPTION
Fixes #79 - SEGFAULT on Openbox and  terminalExeName when terminal is launched from Thunar