### PR TITLE
fix: check if `processName` is NULL/empty to prevent segfaults

### DIFF
--- a/src/common/detectWMDE.c
+++ b/src/common/detectWMDE.c
@@ -66,6 +66,9 @@ static void getSessionDesktop(FFWMDEResult* result)
 
 static void applyPrettyNameIfWM(FFWMDEResult* result, const char* processName, ProtocolHint* protocolHint)
 {
+    if(processName == NULL || *processName == '\0')
+        return;
+
     if(strcasecmp(processName, "kwin_wayland") == 0)
     {
         ffStrbufSetS(&result->wmPrettyName, "KWin");


### PR DESCRIPTION
fastfetch segfaults when using Wayland with river and sway on my system. I found that `processName` (i.e. `sessionDesktop`) in `applyPrettyNameIfWM` is NULL (as in https://github.com/LinusDierheimer/fastfetch/issues/83#issuecomment-942442166), so this adds a check to prevent the segfault like `applyPrettyNameIfDE` does.