### PR TITLE
Packages: use the official librpm instead of libsqlite3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,12 +110,12 @@ else(XFCONF_FOUND)
     message(WARNING "Package libxfconf-0 not found. Building without support.")
 endif(XFCONF_FOUND)
 
-pkg_check_modules (SQLITE3 sqlite3)
-if(SQLITE3_FOUND)
-    add_compile_definitions(FF_HAVE_SQLITE3=1)
-else(SQLITE3_FOUND)
-    message(WARNING "Package sqlite3 not found. Building without support.")
-endif(SQLITE3_FOUND)
+pkg_check_modules (RPM rpm)
+if(RPM_FOUND)
+    add_compile_definitions(FF_HAVE_RPM=1)
+else(RPM_FOUND)
+    message(WARNING "Package librpm not found. Building without support.")
+endif(RPM_FOUND)
 
 include_directories(
     ${PROJECT_BINARY_DIR}
@@ -127,7 +127,7 @@ include_directories(
     ${GIO_INCLUDE_DIRS}
     ${DCONF_INCLUDE_DIRS}
     ${XFCONF_INCLUDE_DIRS}
-    ${SQLITE3_INCLUDE_DIRS}
+    ${RPM_INCLUDE_DIRS}
 )
 
 link_libraries(

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ The following libraries are used if present:
 *  [`libpci`](https://github.com/pciutils/pciutils): Needed for GPU output. _Should_ be available on every linux system.
 *  [`libX11`](https://gitlab.freedesktop.org/xorg/lib/libx11): Needed for resolution output
 *  [`libXrandr`](https://gitlab.freedesktop.org/xorg/lib/libxrandr): Needed for appending refresh rate to resolution output.
-*  [`libwayland-client`](https://wayland.freedesktop.org/): Better resolution performance in wayland sessions.  
+*  [`libwayland-client`](https://wayland.freedesktop.org/): Better resolution performance in wayland sessions.
 *  [`libGIO`](https://developer.gnome.org/gio/unstable/): Needed for values that are only stored GSettings.
 *  [`libDConf`](https://developer.gnome.org/dconf/unstable/): Needed for values that are only stored in DConf + Fallback for GSettings.
-*  [`libXFConf`](https://gitlab.xfce.org/xfce/xfconf): Needed for XFWM theme and XFCE Terminal font.  
-*  [`libSQLite3`](https://www.sqlite.org/index.html): Needed for rpm package count.  
+*  [`libXFConf`](https://gitlab.xfce.org/xfce/xfconf): Needed for XFWM theme and XFCE Terminal font.
+*  [`librpm`](http://rpm.org/): Needed for rpm package count.
 
 ## Support status
 All categories not listed here should work without needing a specific implementation.

--- a/completions/bash
+++ b/completions/bash
@@ -198,7 +198,7 @@ __fastfetch_completion()
         "--lib-DConf"
         "--lib-wayland"
         "--lib-XFConf"
-        "--lib-SQLite"
+        "--lib-RPM"
         "--battery-dir"
         "--load-config"
     )

--- a/src/common/init.c
+++ b/src/common/init.c
@@ -179,7 +179,7 @@ static void defaultConfig(FFinstance* instance)
     ffStrbufInitA(&instance->config.libDConf, 1);
     ffStrbufInitA(&instance->config.libWayland, 1);
     ffStrbufInitA(&instance->config.libXFConf, 1);
-    ffStrbufInitA(&instance->config.libSQLite, 1);
+    ffStrbufInitA(&instance->config.librpm, 1);
 
     ffStrbufInitA(&instance->config.diskFolders, 1);
 

--- a/src/data/config.txt
+++ b/src/data/config.txt
@@ -165,4 +165,4 @@
 #--lib-DConf /usr/lib/libdconf.so
 #--lib-wayland /usr/lib/libwayland-client.so
 #--lib-XFConf /usr/lib/libxfconf-0.so
-#--lib-SQLite /usr/lib/libsqlite3.so
+#--lib-rpm /usr/lib/librpm.so

--- a/src/data/help.txt
+++ b/src/data/help.txt
@@ -93,7 +93,7 @@ Library options: Set the path of a library to load
    --lib-DConf <path>
    --lib-wayland <path>
    --lib-XFConf <path>
-   --lib-SQLite <path>
+   --lib-RPM <path>
 
 Module specific options:
    --disk-folders <folders>:     A colon separated list of folder paths for the disk output. Default is "/:/home"

--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -364,8 +364,8 @@ static inline void listSupportedFeatures()
         #ifdef FF_HAVE_XFCONF
             "xfconf\n"
         #endif
-        #ifdef FF_HAVE_SQLITE3
-            "sqlite3\n"
+        #ifdef FF_HAVE_RPM
+            "librpm\n"
         #endif
         ""
     , stdout);
@@ -745,8 +745,8 @@ static void parseOption(FFinstance* instance, FFdata* data, const char* key, con
         optionParseString(key, value, &instance->config.libWayland);
     else if(strcasecmp(key, "--lib-XFConf") == 0)
         optionParseString(key, value, &instance->config.libXFConf);
-    else if(strcasecmp(key, "--lib-SQLite") == 0)
-        optionParseString(key, value, &instance->config.libSQLite);
+    else if(strcasecmp(key, "--lib-rpm") == 0)
+        optionParseString(key, value, &instance->config.librpm);
     else if(strcasecmp(key, "--disk-folders") == 0)
         optionParseString(key, value, &instance->config.diskFolders);
     else if(strcasecmp(key, "--battery-dir") == 0)

--- a/src/fastfetch.h
+++ b/src/fastfetch.h
@@ -104,7 +104,7 @@ typedef struct FFconfig
     FFstrbuf libGIO;
     FFstrbuf libDConf;
     FFstrbuf libXFConf;
-    FFstrbuf libSQLite;
+    FFstrbuf librpm;
 
     FFstrbuf diskFolders;
 
@@ -337,7 +337,7 @@ FFvariant ffSettingsGetGSettings(FFinstance* instance, const char* schemaName, c
 FFvariant ffSettingsGet(FFinstance* instance, const char* dconfKey, const char* gsettingsSchemaName, const char* gsettingsPath, const char* gsettingsKey, FFvarianttype type);
 FFvariant ffSettingsGetXFConf(FFinstance* instance, const char* channelName, const char* propertyName, FFvarianttype type);
 
-uint32_t ffSettingsGetSQLiteColumnCount(FFinstance* instance, const char* fileName, const char* tableName);
+uint32_t ffSettingsGetRpmPackageCount(FFinstance* instance);
 
 #ifdef __ANDROID__
 void ffSettingsGetAndroidProperty(const char* propName, FFstrbuf* result);

--- a/src/modules/packages.c
+++ b/src/modules/packages.c
@@ -62,7 +62,7 @@ void ffPrintPackages(FFinstance* instance)
     dpkg += getNumStrings("/data/data/com.termux/files/usr/var/lib/dpkg/status", "Status: ");
 #endif
 
-    uint32_t rpm = ffSettingsGetSQLiteColumnCount(instance, "/var/lib/rpm/rpmdb.sqlite", "Packages");
+    uint32_t rpm = ffSettingsGetRpmPackageCount(instance);
     uint32_t xbps = getNumElements("/var/db/xbps", DT_REG);
     uint32_t flatpak = getNumElements("/var/lib/flatpak/app", DT_DIR);
     uint32_t snap = getNumElements("/snap", DT_DIR);


### PR DESCRIPTION
To count installed rpm packages, which support CentOS

![image](https://user-images.githubusercontent.com/6134068/140608219-859287e9-4ad6-4dcc-b405-01f04b28a416.png)

Ref: https://ftp.osuosl.org/pub/rpm/api/4.11.1/group__rpmdb.html#ga0b2fac12a598a46a3f0780fab05839a0

Tested on Centos 7 (RPM version 4.11.3) / 8 (RPM version 4.14.3), should works on RHEL 7 / 8 too.

TODO: Test on Fedora