### PR TITLE
Add CentOS logo support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.1.0) # Threads::Threads is needed
 
-project(fastfetch)
+project(fastfetch LANGUAGES C)
 
 option(BUILD_TESTS "Build test programs" OFF)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ All categories not listed here should work without needing a specific implementa
 
 ##### Logos
 ```
-Arch, Artix, Debian, Fedora, Fedora old, Garuda, Gentoo, Manjaro, Mint, Pop!_OS, Ubuntu, Void
+Arch, Artix, CentOS, Debian, Fedora, Fedora old, Garuda, Gentoo, Manjaro, Mint, Pop!_OS, Ubuntu, Void
 ```
 > **_NOTE:_** Unknown/unsupported logos will be replaced with a question mark when running fastfetch.
 

--- a/src/common/logo.c
+++ b/src/common/logo.c
@@ -348,6 +348,35 @@ static void initLogoVoid(FFinstance* instance)
     instance->config.logo.colors[1] = "\033[30m"; //black
 }
 
+static void initLogoCentOS(FFinstance* instance)
+{
+    instance->config.logo.lines =
+        "$1                 ..                 \n"
+        "$1               .PLTJ.               \n"
+        "$1              <><><><>              \n"
+        "$2     KKSSV' 4KKK $1LJ$4 KKKL.'VSSKK     \n"
+        "$2     KKV' 4KKKKK $1LJ$4 KKKKAL 'VKK     \n"
+        "$2     V' ' 'VKKKK $1LJ$4 KKKKV' ' 'V     \n"
+        "$2     .4MA.' 'VKK $1LJ$4 KKV' '.4Mb.     \n"
+        "$4   . $2KKKKKA.' 'V $1LJ$4 V' '.4KKKKK $3.   \n"
+        "$4 .4D $2KKKKKKKA.'' $1LJ$4 ''.4KKKKKKK $3FA. \n"
+        "$4<QDD ++++++++++++  $3++++++++++++ GFD>\n"
+        "$4 'VD $3KKKKKKKK'.. $2LJ $1..'KKKKKKKK $3FV  \n"
+        "$4   ' $3VKKKKK'. .4 $2LJ $1K. .'KKKKKV $3'   \n"
+        "$3      'VK'. .4KK $2LJ $1KKA. .'KV'      \n"
+        "$3     A. . .4KKKK $2LJ $1KKKKA. . .4     \n"
+        "$3     KKA. 'KKKKK $2LJ $1KKKKK' .4KK     \n"
+        "$3     KKSSA. VKKK $2LJ $1KKKV .4SSKK     \n"
+        "$2              <><><><>              \n"
+        "$1               'MKKM'               \n"
+        "$1                 ''                 ";
+    instance->config.logo.colors[0] = "\033[33m"; //yellow
+    instance->config.logo.colors[1] = "\033[32m"; //green
+    instance->config.logo.colors[2] = "\033[34m"; //blue
+    instance->config.logo.colors[3] = "\033[35m"; //magenta
+    instance->config.logo.colors[4] = "\033[37m"; //white
+}
+
 static bool loadLogoSet(FFinstance* instance, const char* logo)
 {
     if(instance->config.logo.freeable)
@@ -391,6 +420,8 @@ static bool loadLogoSet(FFinstance* instance, const char* logo)
         initLogoUbuntu(instance);
     else if(strcasecmp(logo, "void") == 0)
         initLogoVoid(instance);
+    else if(strcasecmp(logo, "centos") == 0)
+        initLogoCentOS(instance);
     else
         return false;
 
@@ -611,4 +642,3 @@ void ffPrintLogos(FFinstance* instance)
 }
 
 #endif
-


### PR DESCRIPTION
Logo is used from neofetch

![image](https://user-images.githubusercontent.com/6134068/140679999-91120dc1-b52a-4b26-a2fc-29350977ce0d.png)

Also removes C++ compiler requirement in CMakeList as this project is a pure C project