### PR TITLE
Add packaging for Debian based distributions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 cscope.*
 tags
 fastfetch.kdev4
+**/*.deb
+packaging/deb/fastfetch

--- a/packaging/deb/control-template
+++ b/packaging/deb/control-template
@@ -1,0 +1,13 @@
+Package: fastfetch
+Version: <VERSION>
+Section: utils
+Priority: extra
+Architecture: amd64
+Maintainer: peter@bohner.me
+Homepage: https://github.com/LinusDierheimer/fastfetch
+Installed-Size: 410K
+Description: A fast alternative to neofetch
+ fastfetch is a neofetch-like tool for fetching system information and
+ displaying them in a pretty way. It is written in c to achieve much better
+ performance, in return only Linux and Android are supported. It also uses
+ mechanisms like multithreading and caching to finish as fast as possible.

--- a/packaging/deb/create-deb-pkg.sh
+++ b/packaging/deb/create-deb-pkg.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit
 echo "cleanup"
 rm -rf ./build ./fastfetch fastfetch.deb
 
 echo "building fastfetch"
 mkdir build
-cd build
+cd build || exit
 cmake ../../..
-cmake --build . -j$(nproc)
+cmake --build . --target fastfetch "-j$(nproc)"
 
 echo "generating package contents"
 # deb versions must start with a number, hence the 1 added before the rXXX
@@ -21,7 +21,6 @@ sed "s/<VERSION>/$version/g" control-template > fastfetch/DEBIAN/control
 
 mkdir -p fastfetch/usr/bin
 cp build/fastfetch fastfetch/usr/bin/
-cp build/flashfetch fastfetch/usr/bin/
 mkdir -p fastfetch/usr/share/bash-completion/completions
 cp ../../completions/bash fastfetch/usr/share/bash-completion/completions/fastfetch
 

--- a/packaging/deb/create-deb-pkg.sh
+++ b/packaging/deb/create-deb-pkg.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+echo "cleanup"
+rm -rf ./build ./fastfetch fastfetch.deb
+
+echo "building fastfetch"
+mkdir build
+cd build
+cmake ../../..
+cmake --build . -j$(nproc)
+
+echo "generating package contents"
+# deb versions must start with a number, hence the 1 added before the rXXX
+version="0:1$(./fastfetch --version | cut -d ' ' -f2)-0"
+echo "Using package version: $version"
+cd ..
+
+mkdir -p fastfetch/DEBIAN
+sed "s/<VERSION>/$version/g" control-template > fastfetch/DEBIAN/control
+
+mkdir -p fastfetch/usr/bin
+cp build/fastfetch fastfetch/usr/bin/
+cp build/flashfetch fastfetch/usr/bin/
+mkdir -p fastfetch/usr/share/bash-completion/completions
+cp ../../completions/bash fastfetch/usr/share/bash-completion/completions/fastfetch
+
+echo "building package"
+dpkg-deb --build fastfetch
+echo "package built."
+echo "cleaning up"
+rm -rf build fastfetch

--- a/packaging/deb/create-deb-pkg.sh
+++ b/packaging/deb/create-deb-pkg.sh
@@ -23,6 +23,8 @@ mkdir -p fastfetch/usr/bin
 cp build/fastfetch fastfetch/usr/bin/
 mkdir -p fastfetch/usr/share/bash-completion/completions
 cp ../../completions/bash fastfetch/usr/share/bash-completion/completions/fastfetch
+mkdir -p fastfetch/usr/share/fastfetch/
+cp -r ../../presets fastfetch/usr/share/fastfetch/
 
 echo "building package"
 dpkg-deb --build fastfetch


### PR DESCRIPTION
This commit adds a script (`create-deb-pkg.sh`), which creates a deb package containing the fastfetch and flashfetch executables as well as the bash-completion file. The script must be executed in an environment, where `dpkg-deb` is present (a debian based environment).
Because Deb versioning is not compatible with fastfetch version strings, it is adapted to the format: `0:1$FF_VERSION-0`.