### PR TITLE
Fix build if ImageMagick is not installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1.0) # Threads::Threads
 
 project(fastfetch
-    VERSION 1.5.1
+    VERSION 1.5.2
     LANGUAGES C
 )
 

--- a/src/logo/image/image.c
+++ b/src/logo/image/image.c
@@ -563,7 +563,7 @@ bool ffLogoPrintImageIfExists(FFinstance* instance, FFLogoType type)
 }
 
 #else //FF_HAVE_IMAGEMAGICK{6, 7}
-FFLogoImageResult ffLogoPrintImageIfExists(FFinstance* instance, FFLogoType type)
+bool ffLogoPrintImageIfExists(FFinstance* instance, FFLogoType type)
 {
     FF_UNUSED(instance, type);
     return false;


### PR DESCRIPTION
The current build fails if ImageMagick is not installed, since the return type wasn't changed to `bool`. This PR fixes it.

BTW, I'm packaging fastfetch for NixOS: https://github.com/NixOS/nixpkgs/pull/176819/ 