### PR TITLE
Add CPU package temperature to CPU format string

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,7 @@ Here i just add things that are easy to forget.
   - `libffprint`: contains the printing functions, logos, format etc
   - `fastfetch` and `flashfetch`: Executables, that initialize the config of libffprint. Fist one at runtime, second one at compile time
 - [ ] Better OS output for all possible combinations of /etc/os-release variables.
-- [ ] Expose temperatures to CPU format string
+- [X] Expose temperatures to CPU format string
 - [ ] Expose temperatures to GPU format string
 - [ ] Find wayland compositor by looking at \${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}
 - [ ] Make LocalIP module more configurable

--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -236,7 +236,7 @@ static inline void printCommandHelp(const char* command)
     }
     else if(strcasecmp(command, "cpu-format") == 0)
     {
-        constructAndPrintCommandHelpFormat("cpu", "{2} ({7}) @ {14}GHz", 14,
+        constructAndPrintCommandHelpFormat("cpu", "{2} ({7}) @ {15}GHz ({8}°C)", 15,
             "CPU name",
             "Prettified CPU name",
             "CPU Vendor name (Vendor ID)",
@@ -244,6 +244,7 @@ static inline void printCommandHelp(const char* command)
             "CPU logical core count configured",
             "CPU physical core count",
             "Always set core count",
+            "CPU package temperature",
             "frequency bios limit",
             "frequency scaling max",
             "frequency scaling min",


### PR DESCRIPTION
This PR adds basic support for CPU package temperature in the CPU format string.

This is done by looking for a specified thermal zone in
/sys/class/thermal/thermal_zone*/ .
Unfortunately there is no better way to find the
temperature, then to check all registered zones.
This still needs to be extended to support other hardware,
right now only x86 CPUs and Raspberry pi are tested.
Maybe the FF_CPU_THERMAL_ZONES array could be user configurable,
but I could not figure out how to add an array as a config parameter.
