### PR TITLE
Quality of life improvement: make run.sh not run ff, if the build fails

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,9 @@
 #!/bin/env sh
+
+# make the script exit if any of the commands fail,
+# making fastfetch not run if the build failed.
+set -e
+
 mkdir -p build/
 cd build/
 cmake ..


### PR DESCRIPTION
If `set -e` is used, the script will not run `build/fastfetch` if the build failed.