### PR TITLE
Add CPU package temperature to CPU module.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,7 @@ add_library(libfastfetch OBJECT
     src/detection/vulkan.c
     src/detection/media.c
     src/detection/datetime.c
+    src/detection/temps.c
     src/detection/displayserver/displayServer.c
     src/detection/displayserver/wayland.c
     src/detection/displayserver/xcb.c

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,7 @@ Here i just add things that are easy to forget.
   - `libffprint`: contains the printing functions, logos, format etc
   - `fastfetch` and `flashfetch`: Executables, that initialize the config of libffprint. Fist one at runtime, second one at compile time
 - [ ] Better OS output for all possible combinations of /etc/os-release variables.
-- [ ] Expose temperatures to CPU format string
+- [X] Expose temperatures to CPU format string
 - [ ] Expose temperatures to GPU format string
 - [ ] Find wayland compositor by looking at \${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}
 - [ ] Make LocalIP module more configurable

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -12,7 +12,6 @@ Here i just add things that are easy to forget.
   - `libffprint`: contains the printing functions, logos, format etc
   - `fastfetch` and `flashfetch`: Executables, that initialize the config of libffprint. Fist one at runtime, second one at compile time
 - [ ] Better OS output for all possible combinations of /etc/os-release variables.
-- [X] Expose temperatures to CPU format string
 - [ ] Expose temperatures to GPU format string
 - [ ] Find wayland compositor by looking at \${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY:-wayland-0}
 - [ ] Make LocalIP module more configurable

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,9 @@
 #!/bin/env sh
+
+# make the script exit if any of the commands fail,
+# making fastfetch not run if the build failed.
+set -e
+
 mkdir -p build/
 cd build/
 cmake ..

--- a/src/detection/temps.c
+++ b/src/detection/temps.c
@@ -7,10 +7,7 @@
 static bool isTempFile(const char* name)
 {
     return
-        name[0] == 't' &&
-        name[1] == 'e' &&
-        name[2] == 'm' &&
-        name[3] == 'p' &&
+        strncmp(name, "temp", 4) == 0 &&
         name[4] >= '0' &&
         name[4] <= '9' &&
         strncmp(name + 5, "_input", 6) == 0;

--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -236,7 +236,7 @@ static inline void printCommandHelp(const char* command)
     }
     else if(strcasecmp(command, "cpu-format") == 0)
     {
-        constructAndPrintCommandHelpFormat("cpu", "{2} ({7}) @ {14}GHz", 14,
+        constructAndPrintCommandHelpFormat("cpu", "{2} ({7}) @ {15}GHz ({8}°C)", 15,
             "CPU name",
             "Prettified CPU name",
             "CPU Vendor name (Vendor ID)",
@@ -244,6 +244,7 @@ static inline void printCommandHelp(const char* command)
             "CPU logical core count configured",
             "CPU physical core count",
             "Always set core count",
+            "CPU package temperature",
             "frequency bios limit",
             "frequency scaling max",
             "frequency scaling min",

--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -236,7 +236,7 @@ static inline void printCommandHelp(const char* command)
     }
     else if(strcasecmp(command, "cpu-format") == 0)
     {
-        constructAndPrintCommandHelpFormat("cpu", "{2} ({7}) @ {15}GHz ({8}°C)", 15,
+        constructAndPrintCommandHelpFormat("cpu", "{2} ({7}) @ {15}GHz", 15,
             "CPU name",
             "Prettified CPU name",
             "CPU Vendor name (Vendor ID)",

--- a/src/modules/cpu.c
+++ b/src/modules/cpu.c
@@ -7,9 +7,10 @@
 #define FF_CPU_NUM_FORMAT_ARGS 15
 
 
-static long parseLong(const FFstrbuf* content) {
+static long parseLong(const FFstrbuf* content)
+{
     long value;
-    if(content->length == 0 || (sscanf(content->chars, "%li", &value) != 1))
+    if(sscanf(content->chars, "%li", &value) != 1)
         return -1;
     return value;
 
@@ -17,9 +18,6 @@ static long parseLong(const FFstrbuf* content) {
 
 static double parseHz(const FFstrbuf* content)
 {
-    if(content->length == 0)
-        return 0;
-
     double herz;
     if(sscanf(content->chars, "%lf", &herz) != 1)
         return 0;
@@ -117,7 +115,8 @@ void ffPrintCPU(FFinstance* instance)
 
     const FFTempsResult *temps = ffDetectTemps(&instance);
     double cpuTemp = 0.0/0.0;
-    for(uint32_t i = 0; i< temps->values.length; i++) {
+    for(uint32_t i = 0; i< temps->values.length; i++)
+    {
         FFTempValue *v = ffListGet(&temps->values, i);
         if(ffStrbufFirstIndexS(&v->name, "cpu") == v->name.length
             && ffStrbufCompS(&v->name, "k10temp") != 0


### PR DESCRIPTION
New PR, because I messed up my fork and had to delete and re-fork it, which closed the previous PR.


This PR adds basic support for CPU package temperature in the CPU format string.

This is done by looking for a specified thermal zone in
/sys/class/thermal/thermal_zone*/ .
Unfortunately there is no better way to find the
temperature, then to check all registered zones.
This still needs to be extended to support other hardware,
right now only x86 CPUs and Raspberry pi are tested.
Maybe the FF_CPU_THERMAL_ZONES array could be user configurable,
but I could not figure out how to add an array as a config parameter.