### PR TITLE
Fix build error on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12.0) # target_link_libraries with OBJECT libs
 
 project(fastfetch
-    VERSION 1.6.0
+    VERSION 1.6.1
     LANGUAGES C
 )
 

--- a/src/modules/host.c
+++ b/src/modules/host.c
@@ -9,7 +9,7 @@
 
 #ifndef __ANDROID__
     #include "common/io.h"
-#elif
+#else
     #include <ctype.h>
 #endif
 


### PR DESCRIPTION
host.c has an #elif, but actually #else is needed.
Related issue: https://github.com/termux/termux-packages/issues/11361.