### PR TITLE
Add KISS Linux logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Title, Separator, OS, Host, Kernel, Uptime, Processes, Packages, Shell, Resoluti
 
 ##### Logos
 ```
-Alpine, Android, Arch, Arco, Artix, Bedrock, CachyOS, CentOS, Debian, Devuan, Deepin, Endeavour, Fedora, Garuda, Gentoo, KDE Neon, Kubuntu, Linux, Manjaro, Mint, NixOS, OpenSUSE, OpenSUSE Tumbleweed, OpenSUSE LEAP, Pop!_OS, RebornOS, RedstarOS, Rocky, Rosa, Ubuntu, Void, Zorin
+Alpine, Android, Arch, Arco, Artix, Bedrock, CachyOS, CentOS, Debian, Devuan, Deepin, Endeavour, Fedora, Garuda, Gentoo, KDE Neon, KISS, Kubuntu, Linux, Manjaro, Mint, NixOS, OpenSUSE, OpenSUSE Tumbleweed, OpenSUSE LEAP, Pop!_OS, RebornOS, RedstarOS, Rocky, Rosa, Ubuntu, Void, Zorin
 ```
 * Most of the logos have a small variant. Access it by appending _small to the logo name.
 * Some logos have an old variant. Access it by appending _old to the logo name.

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -775,6 +775,26 @@ static const FFlogo* getLogoKDENeon()
     FF_LOGO_RETURN
 }
 
+static const FFlogo* getLogoKISSLinux()
+{
+    FF_LOGO_INIT
+    FF_LOGO_NAMES("kiss", "kiss-linux", "kisslinux")
+    FF_LOGO_LINES(
+        "    ___      \n"
+        "   (.· |     \n"
+        "   (<> |     \n"
+        "  / __  \\    \n"
+        " ( /  \ /|   \n"
+        "_/\\ __)/_)   \n"
+        "\\/-____\\/    \n"
+    )
+    FF_LOGO_COLORS(
+        "35", //magenta
+        "34" //blue
+    )
+    FF_LOGO_RETURN
+}
+
 static const FFlogo* getLogoKubuntu()
 {
     FF_LOGO_INIT
@@ -1552,6 +1572,7 @@ GetLogoMethod* ffLogoBuiltinGetAll()
         getLogoGentoo,
         getLogoGentooSmall,
         getLogoKDENeon,
+        getLogoKISSLinux,
         getLogoKubuntu,
         getLogoLinux,
         getLogoManjaro,

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -784,7 +784,7 @@ static const FFlogo* getLogoKISSLinux()
         "   (.· |     \n"
         "   (<> |     \n"
         "  / __  \\    \n"
-        " ( /  \ /|   \n"
+        " ( /  \\ /|   \n"
         "_/\\ __)/_)   \n"
         "\\/-____\\/    \n"
     )

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -780,15 +780,16 @@ static const FFlogo* getLogoKISSLinux()
     FF_LOGO_INIT
     FF_LOGO_NAMES("kiss", "kiss-linux", "kisslinux")
     FF_LOGO_LINES(
-        "    ___      \n"
-        "   (.· |     \n"
-        "   (<> |     \n"
-        "  / __  \\    \n"
-        " ( /  \\ /|   \n"
-        "_/\\ __)/_)   \n"
-        "\\/-____\\/    \n"
+        "   $3 ___     \n"
+        "   ($1.· $3|     \n"
+        "   ($2<> $3|     \n"
+        "  / $1__$3  \\    \n"
+        " ( $1/  \\ $3/|   \n"
+        "$2_$3/\\ $1__)$3/$2_$3)   \n"
+        "$2\\/$3-____$2\\/$1    \n"
     )
     FF_LOGO_COLORS(
+        "37", //white
         "35", //magenta
         "34" //blue
     )

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -781,16 +781,16 @@ static const FFlogo* getLogoKISSLinux()
     FF_LOGO_NAMES("kiss", "kiss-linux", "kisslinux")
     FF_LOGO_LINES(
         "   $3 ___     \n"
-        "   ($1.· $3|     \n"
-        "   ($2<> $3|     \n"
-        "  / $1__$3  \\    \n"
+        "   ($2.· $3|     \n"
+        "   ($1<> $3|     \n"
+        "  / $2__$3  \\    \n"
         " ( $1/  \\ $3/|   \n"
-        "$2_$3/\\ $1__)$3/$2_$3)   \n"
-        "$2\\/$3-____$2\\/$1    \n"
+        "$1_$3/\\ $2__)$3/$1_$3)   \n"
+        "$1\\/$3-____$1\\/$2    \n"
     )
     FF_LOGO_COLORS(
-        "37", //white
         "35", //magenta
+        "37", //white
         "34" //blue
     )
     FF_LOGO_RETURN


### PR DESCRIPTION
Logo is once again from @dylanaraps' neofetch.

As a sidenote; I noticed while compiling on KISS, ```#include <sys/time.h>``` needs to be included in src/common/networking.c for a successful compile. 

While I've only got evidence of the compile failure happening under KISS (perhaps as a side-effect of being musl based, though this behavior isn't reproducible on something like Alpine), is this patch something that might be useful to implement into master? 

Below is the failed compile log.

```
/home/draumaz/kiss-logo/src/common/networking.c: In function 'ffNetworkingGetHtt':
/home/draumaz/kiss-logo/src/common/networking.c:29:24: error: storage size of 'timev' isn't known
   29 |         struct timeval timev;
      |                        ^~~~~
/home/draumaz/kiss-logo/src/common/networking.c:29:24: warning: unused variable timev' [-Wunused-variable]
make[2]: *** [CMakeFiles/libfastfetch.dir/build.make:272: CMakeFiles/libfastfetch.dir/src/common/networking.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/libfastfetch.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```