### PR TITLE
Add LangitKetujuh Linux logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Title, Separator, OS, Host, Kernel, Uptime, Processes, Packages, Shell, Resoluti
 
 ##### Logos
 ```
-Alpine, Android, Arch, Arco, Artix, Bedrock, CachyOS, CentOS, Debian, Devuan, Deepin, Endeavour, Fedora, Garuda, Gentoo, KDE Neon, KISS, Kubuntu, Linux, Manjaro, Mint, NixOS, OpenSUSE, OpenSUSE Tumbleweed, OpenSUSE LEAP, Pop!_OS, RebornOS, RedstarOS, Rocky, Rosa, Ubuntu, Void, Zorin
+Alpine, Android, Arch, Arco, Artix, Bedrock, CachyOS, CentOS, Debian, Devuan, Deepin, Endeavour, Fedora, Garuda, Gentoo, KDE Neon, KISS, Kubuntu, LangitKetujuh, Linux, Manjaro, Mint, NixOS, OpenSUSE, OpenSUSE Tumbleweed, OpenSUSE LEAP, Pop!_OS, RebornOS, RedstarOS, Rocky, Rosa, Ubuntu, Void, Zorin
 ```
 * Most of the logos have a small variant. Access it by appending _small to the logo name.
 * Some logos have an old variant. Access it by appending _old to the logo name.

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -829,6 +829,32 @@ static const FFlogo* getLogoKubuntu()
     FF_LOGO_RETURN
 }
 
+static const FFlogo* getLogoLangitKetujuh()
+{
+    FF_LOGO_INIT
+    FF_LOGO_NAMES("l7", "langitketujuh", "LangitKetujuh")
+    FF_LOGO_LINES(
+	"\n"
+	"\n"
+	"   $2. '7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7\n"
+	"   $2L7.   '7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7\n"
+	"   $2L7L7L      7L7L7L7L7L7L7L7L7L7L7L7L7L7\n"
+	"   $2L7L7L7                          L7L7L7\n"
+	"   $2L7L7L7           'L7L7L7L7L7L7L7L7L7L7\n"
+	"   $2L7L7L7               'L7L7L7L7L7L7L7L7\n"
+	"   $2L7L7L7                   'L7L7L7L7L7L7\n"
+	"   $2L7L7L7                          L7L7L7\n"
+	"   $2L7L7L7L7L7L7L7L7L7L7LL7L7L7.    '7L7L7\n"
+	"   $2L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L.   'L7\n"
+	"   $2L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7L7.  '\n"
+    )
+    FF_LOGO_COLORS(
+        "34", //blue
+        "37" //white
+    )
+    FF_LOGO_RETURN
+}
+
 static const FFlogo* getLogoLinux()
 {
     FF_LOGO_INIT
@@ -1575,6 +1601,7 @@ GetLogoMethod* ffLogoBuiltinGetAll()
         getLogoKDENeon,
         getLogoKISSLinux,
         getLogoKubuntu,
+        getLogoLangitKetujuh,
         getLogoLinux,
         getLogoManjaro,
         getLogoManjaroSmall,


### PR DESCRIPTION
based on https://github.com/dylanaraps/neofetch/pull/1824.
ascii logo with letter "L7" as LangitKetujuh linux identity.

![Screenshot_20220803_164228](https://user-images.githubusercontent.com/45872139/182578956-94a4bc77-8bf9-49d0-a2d9-caa8d8c1442a.png)

