### PR TITLE
Fix installation of presets/ directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.3
+
+Fixes installing presets in their own directory (#212)
+
 # 1.6.2
 
 Releasing this, so void linux can package fastfetch.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12.0) # target_link_libraries with OBJECT libs
 
 project(fastfetch
-    VERSION 1.6.2
+    VERSION 1.6.3
     LANGUAGES C
 )
 
@@ -522,7 +522,7 @@ install(
 )
 
 install(
-    DIRECTORY "${CMAKE_SOURCE_DIR}/presets/"
+    DIRECTORY "${CMAKE_SOURCE_DIR}/presets"
     DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/${CMAKE_PROJECT_NAME}"
 )
 


### PR DESCRIPTION
In 1.6.2, presets are installed directly inside `/usr/share/fastfetch` instead of `/usr/share/fastfetch/presets`