### PR TITLE
Issue 223 pull request

### DIFF
--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -230,10 +230,17 @@ static inline void printCommandHelp(const char* command)
     }
     else if(strcasecmp(command, "terminal-format") == 0)
     {
-        constructAndPrintCommandHelpFormat("terminal", "{3}", 3,
+        constructAndPrintCommandHelpFormat("terminal", "{3}", 10,
             "Terminal process name",
             "Terminal path with exe name",
-            "Terminal exe name"
+            "Terminal exe name",
+            "Shell process name",
+            "Shell path with exe name",
+            "Shell exe name",
+            "Shell version",
+            "User shell path with exe name",
+            "User shell exe name",
+            "User shell version"
         );
     }
     else if(strcasecmp(command, "terminal-font-format") == 0)

--- a/src/modules/terminal.c
+++ b/src/modules/terminal.c
@@ -5,7 +5,7 @@
 #include <string.h>
 
 #define FF_TERMINAL_MODULE_NAME "Terminal"
-#define FF_TERMINAL_NUM_FORMAT_ARGS 3
+#define FF_TERMINAL_NUM_FORMAT_ARGS 10
 
 void ffPrintTerminal(FFinstance* instance)
 {
@@ -31,7 +31,14 @@ void ffPrintTerminal(FFinstance* instance)
         ffPrintFormat(instance, FF_TERMINAL_MODULE_NAME, 0, &instance->config.terminal, FF_TERMINAL_NUM_FORMAT_ARGS, (FFformatarg[]){
             {FF_FORMAT_ARG_TYPE_STRBUF, &result->terminalProcessName},
             {FF_FORMAT_ARG_TYPE_STRBUF, &result->terminalExe},
-            {FF_FORMAT_ARG_TYPE_STRING, result->terminalExeName}
+            {FF_FORMAT_ARG_TYPE_STRING, result->terminalExeName},
+            {FF_FORMAT_ARG_TYPE_STRBUF, &result->shellProcessName},
+            {FF_FORMAT_ARG_TYPE_STRBUF, &result->shellExe},
+            {FF_FORMAT_ARG_TYPE_STRING, result->shellExeName},
+            {FF_FORMAT_ARG_TYPE_STRBUF, &result->shellVersion},
+            {FF_FORMAT_ARG_TYPE_STRBUF, &result->userShellExe},
+            {FF_FORMAT_ARG_TYPE_STRING, result->userShellExeName},
+            {FF_FORMAT_ARG_TYPE_STRBUF, &result->userShellVersion}
         });
     }
 }


### PR DESCRIPTION
Added the changes mentioned in #223 to the terminal-format options to enable combining the terminal and shell outputs onto the same line.

User can now use options {1} - {3} for terminal output, and options {4} - {10} for shell output.
The --help output has been updated as well.