### PR TITLE
OpenGL / OpenCL: add macOS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,8 @@ cmake_dependent_option(ENABLE_ZLIB "Enable zlib" ON "ENABLE_IMAGEMAGICK6 OR ENAB
 cmake_dependent_option(ENABLE_EGL "Enable egl" ON "LINUX" OFF)
 cmake_dependent_option(ENABLE_GLX "Enable glx" ON "LINUX" OFF)
 cmake_dependent_option(ENABLE_OSMESA "Enable osmesa" ON "LINUX" OFF)
-cmake_dependent_option(ENABLE_OPENCL "Enable opencl" ON "LINUX" OFF)
+cmake_dependent_option(ENABLE_APPLECGL "Enable apple-cgl" ON "APPLE" OFF)
+cmake_dependent_option(ENABLE_OPENCL "Enable opencl" ON "LINUX OR APPLE" OFF)
 
 option(BUILD_TESTS "Build tests" OFF) # Also create test executables
 option(SET_TWEAK "Add tweak to project version" ON) # This is set to off by github actions for release builds
@@ -309,10 +310,34 @@ ff_check_lib(IMAGEMAGICK7 MagickCore-7.Q16HDRI MagickCore-7.Q16 /usr/lib/imagema
 ff_check_lib(IMAGEMAGICK6 MagickCore-6.Q16HDRI MagickCore-6.Q16 /usr/lib/imagemagick6/pkgconfig/MagickCore-6.Q16HDRI.pc /usr/lib/imagemagick6/pkgconfig/MagickCore-6.Q16.pc)
 ff_check_lib(ZLIB zlib)
 ff_check_lib(CHAFA chafa>=1.10)
-ff_check_lib(EGL egl)
-ff_check_lib(GLX glx)
-ff_check_lib(OSMESA osmesa)
-ff_check_lib(OPENCL OpenCL)
+
+if(APPLE)
+    # Apple framework bundles can't be found by pkg-config
+    if(ENABLE_APPLECGL)
+        find_package(OpenGL)
+        if(OpenGL_FOUND)
+            target_compile_definitions(libfastfetch PRIVATE FF_HAVE_APPLECGL=1)
+            target_link_libraries(libfastfetch PRIVATE ${OPENGL_LIBRARIES})
+        else()
+            message(WARNING "Package Apple-CGL not found, building without support.")
+        endif()
+    endif()
+
+    if(ENABLE_OPENCL)
+        find_package(OpenCL)
+        if(OpenCL_FOUND)
+            target_compile_definitions(libfastfetch PRIVATE FF_HAVE_OPENCL=1)
+            target_link_libraries(libfastfetch PRIVATE ${OpenCL_LIBRARY})
+            else()
+            message(WARNING "Package OpenCL not found, building without support.")
+        endif()
+    endif()
+else()
+    ff_check_lib(EGL egl)
+    ff_check_lib(GLX glx)
+    ff_check_lib(OSMESA osmesa)
+    ff_check_lib(OPENCL OpenCL)
+endif()
 
 target_include_directories(libfastfetch
     PUBLIC ${PROJECT_BINARY_DIR}

--- a/src/common/init.c
+++ b/src/common/init.c
@@ -430,6 +430,9 @@ void ffListFeatures()
         #ifdef FF_HAVE_OSMESA
             "osmesa\n"
         #endif
+        #ifdef FF_HAVE_APPLECGL
+            "apple-cgl\n"
+        #endif
         #ifdef FF_HAVE_OPENCL
             "opencl\n"
         #endif

--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -1258,6 +1258,7 @@ static void parseOption(FFinstance* instance, FFdata* data, const char* key, con
             "egl", FF_GL_TYPE_EGL,
             "glx", FF_GL_TYPE_GLX,
             "osmesa", FF_GL_TYPE_OSMESA,
+            "apple-cgl", FF_GL_TYPE_APPLECGL,
             NULL
         );
     }

--- a/src/fastfetch.h
+++ b/src/fastfetch.h
@@ -50,7 +50,8 @@ typedef enum FFGLType
     FF_GL_TYPE_AUTO,
     FF_GL_TYPE_EGL,
     FF_GL_TYPE_GLX,
-    FF_GL_TYPE_OSMESA
+    FF_GL_TYPE_OSMESA,
+    FF_GL_TYPE_APPLECGL
 } FFGLType;
 
 typedef struct FFModuleArgs

--- a/src/modules/opencl.c
+++ b/src/modules/opencl.c
@@ -10,7 +10,11 @@
 #include <string.h>
 
 #define CL_TARGET_OPENCL_VERSION 100
+#ifdef __APPLE__
+#include <OpenCL/cl.h>
+#else
 #include <CL/cl.h>
+#endif
 
 typedef struct OpenCLData
 {
@@ -75,13 +79,21 @@ static const char* printOpenCL(FFinstance* instance)
 {
     OpenCLData data;
 
+    #ifdef __APPLE__
+    data.ffclGetPlatformIDs = clGetPlatformIDs;
+    data.ffclGetDeviceIDs = clGetDeviceIDs;
+    data.ffclGetDeviceInfo = clGetDeviceInfo;
+    #else
     FF_LIBRARY_LOAD(opencl, instance->config.libOpenCL, "dlopen libOpenCL.so failed", "libOpenCL.so", 1);
     FF_LIBRARY_LOAD_SYMBOL_VAR_MESSAGE(opencl, data, clGetPlatformIDs);
     FF_LIBRARY_LOAD_SYMBOL_VAR_MESSAGE(opencl, data, clGetDeviceIDs);
     FF_LIBRARY_LOAD_SYMBOL_VAR_MESSAGE(opencl, data, clGetDeviceInfo);
+    #endif
 
     const char* error = openCLHandelData(instance, &data);
+    #ifndef __APPLE__
     dlclose(opencl);
+    #endif
     return error;
 }
 #endif


### PR DESCRIPTION
Note: FF_LIBRARY_LOAD and friends are not used because loading framework bundles are not supported by FF_LIBRARY_LOAD and support it is not easy. Since CGL is guaranteed to be supported by macOS system, we simply use static linking in this case.

<img width="569" alt="image" src="https://user-images.githubusercontent.com/6134068/189859191-72660f16-24fe-45e7-a443-be26852b6b89.png">

