### PR TITLE
Fix bash completions file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.7.2
+
+Fixes the bash completions
+
 # 1.7.1
 
 This release brings a lot of bug fixes and improvements for MacOS. Big thanks to @CarterLi for the help on this!

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12.0) # target_link_libraries with OBJECT libs & project homepage url
 
 project(fastfetch
-    VERSION 1.7.1
+    VERSION 1.7.2
     LANGUAGES C
     DESCRIPTION "Fast system information tool"
     HOMEPAGE_URL "https://github.com/LinusDierheimer/fastfetch"

--- a/completions/bash
+++ b/completions/bash
@@ -387,5 +387,6 @@ __fastfetch_completion()
     else
         __fastfetch_complete_option
     fi
+}
 
 complete -F __fastfetch_completion fastfetch


### PR DESCRIPTION
This is a trivial fix, the bash completions file in 1.7.1 cannot be sourced

If you don't want to make a new release for a 1 line change I can revert CMakeLists and CHANGELOG.