### PR TITLE
Added support for MacPorts package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ AlmaLinux, Alpine, Android, Arch, Arco, Artix, Bedrock, CachyOS, CentOS, Debian,
 
 ##### Package managers
 ```
-Pacman, dpkg, rpm, emerge, xbps, nix, Flatpak, Snap, apk, brew
+Pacman, dpkg, rpm, emerge, xbps, nix, Flatpak, Snap, apk, brew, MacPorts
 ```
 
 ##### WM themes

--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -114,7 +114,7 @@ static inline void printCommandHelp(const char* command)
     }
     else if(strcasecmp(command, "packages-format") == 0)
     {
-        constructAndPrintCommandHelpFormat("packages", "{2} (pacman){?3}[{3}]{?}, {4} (dpkg), {5} (rpm), {6} (emerge), {7} (xbps), {8} (nix-system), {9} (nix-user), {10} (nix-default), {11} (apk), {12} (flatpak), {13} (snap), {14} (brew)", 14,
+        constructAndPrintCommandHelpFormat("packages", "{2} (pacman){?3}[{3}]{?}, {4} (dpkg), {5} (rpm), {6} (emerge), {7} (xbps), {8} (nix-system), {9} (nix-user), {10} (nix-default), {11} (apk), {12} (flatpak), {13} (snap), {14} (brew), {15} (port)", 15,
             "Number of all packages",
             "Number of pacman packages",
             "Pacman branch on manjaro",
@@ -128,7 +128,8 @@ static inline void printCommandHelp(const char* command)
             "Number of apk packages",
             "Number of flatpak packages",
             "Number of snap packages",
-            "Number of brew packages"
+            "Number of brew packages",
+            "Number of macports packages"
         );
     }
     else if(strcasecmp(command, "shell-format") == 0)

--- a/src/modules/packages.c
+++ b/src/modules/packages.c
@@ -13,7 +13,7 @@
 #include <sys/stat.h>
 
 #define FF_PACKAGES_MODULE_NAME "Packages"
-#define FF_PACKAGES_NUM_FORMAT_ARGS 14
+#define FF_PACKAGES_NUM_FORMAT_ARGS 15
 
 typedef struct PackageCounts
 {


### PR DESCRIPTION
I added support for the MacPorts package manager. I followed the format used for the Homebrew package manager located in `src/modules/packages.c`. I added  a `port` member definition to `PackageCounts` struct, a static count and get MacPortsPackages function, and updated the areas which collect/use the package data (lines 392, 461, 519, 545). Tested on M1, but follows MacPorts convention for finding packages in `/opt/local` and/or `$MACPORTS_PREFIX`. 
> "You will need to manually adapt your shell's environment to work with MacPorts and your chosen installation prefix (the value passed to configure's --prefix flag, defaulting to /opt/local)" 
(taken from https://www.macports.org/install.php#git).