### PR TITLE
Font: suppress IO when detecting fonts on macOS

### DIFF
--- a/src/detection/font/font_apple.m
+++ b/src/detection/font/font_apple.m
@@ -1,4 +1,5 @@
 #include "common/font.h"
+#include "common/io.h"
 #include "util/apple/cf_helpers.h"
 #include "font.h"
 
@@ -13,8 +14,10 @@ static void detectFontForType(CTFontUIFontType uiType, FFstrbuf* font)
 void ffDetectFontImpl(const FFinstance* instance, FFFontResult* result)
 {
     FF_UNUSED(instance);
+    ffSuppressIO(true);
     detectFontForType(kCTFontUIFontSystem, &result->fonts[0]);
     detectFontForType(kCTFontUIFontUser, &result->fonts[1]);
     detectFontForType(kCTFontUIFontUserFixedPitch, &result->fonts[2]);
     detectFontForType(kCTFontUIFontApplication, &result->fonts[3]);
+    ffSuppressIO(false);
 }


### PR DESCRIPTION
Removes

* 2022-09-29 07:06:58.649 flashfetch[92995:31447779] XType: com.apple.fonts is not accessible.
* 2022-09-29 07:06:58.649 flashfetch[92995:31447779] XType: XTFontStaticRegistry is enabled.