### PR TITLE
Fix Alpine, EndeavourOS, Rocky, and Rosa logos

### DIFF
--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -87,7 +87,7 @@ static const FFlogo* getLogoAlpine()
         "    +dddddddddddddddddddddddddddddd+\n"
         "  `sdddddddddddddddddddddddddddddddds`\n"
         " `ydddddddddddd++hdddddddddddddddddddy`\n"
-        ".hddddddddddd+`  `+ddddh:-sdddddddddddh.   \n"
+        ".hddddddddddd+`  `+ddddh:-sdddddddddddh.\n"
         "hdddddddddd+`      `+y:    .sddddddddddh\n"
         "ddddddddh+`   `//`   `.`     -sddddddddd\n"
         "ddddddh+`   `/hddh/`   `:s-    -sddddddd\n"
@@ -699,8 +699,8 @@ static const FFlogo* getLogoEndeavour()
         "  $2`:////$1ssssssssssssssssssssssssssso$3+++.\n"
         "$2`-////+$1ssssssssssssssssssssssssssso$3++++-\n"
         " $2`..-+$1oosssssssssssssssssssssssso$3+++++/`\n"
-        "$3./++++++++++++++++++++++++++++++/:.\n"
-        "`:::::::::::::::::::::::::------``"
+        "   $3./++++++++++++++++++++++++++++++/:.\n"
+        "    `:::::::::::::::::::::::::------``"
     )
     FF_LOGO_COLORS(
         "35", //magenta
@@ -1779,7 +1779,7 @@ static const FFlogo* getLogoRockyLinux()
         "jliililiiilililiiili@`  ~ililiiiiiL\n"
         "iiiliiiiliiiiiiili>`      ~liililii\n"
         "liliiiliiilililii`         -9liiiil\n"
-        "iiiiiliiliiiiii~             ''4lili\n"
+        "iiiiiliiliiiiii~             \"4lili\n"
         "4ililiiiiilil~|      -w,       )4lf\n"
         "-liiiiililiF'       _liig,       )'\n"
         " )iiiliii@`       _QIililig,\n"
@@ -1802,7 +1802,7 @@ static const FFlogo* getLogoRosaLinux()
     FF_LOGO_INIT
     FF_LOGO_NAMES("rosa", "rosa-linux", "rosalinux")
     FF_LOGO_LINES(
-        "            ROSAROSAROSAROSAR\n"
+        "           ROSAROSAROSAROSAR\n"
         "        ROSA               AROS\n"
         "      ROS   SAROSAROSAROSAR   AROS\n"
         "    RO   ROSAROSAROSAROSAROSAR   RO\n"


### PR DESCRIPTION
After using regex and diff tools to compare logos between fastfetch and neofetch I found 4 clear mistakes to correct:
1) Alpine's logo had 3 extra spaces on the end of its 7th line.
2) EndeavourOS's logo was missing whitespace indents on its last 2 lines.
3) Rocky's logo had 2 single quotes '' where 1 double quote should be ", making that line extend too far.
4) Rosa's logo had 1 extra space on its first line.

3 additional differences I found but am **NOT** addressing with this pull request:
1) Garuda's logo has an extra line making it taller. It may be a mistake or may be intentional.
2) The Old Mint logo's lower right corner is curved more than the version on neofetch. It may be a mistake.
3) Slackware's logo has two extra characters on its first row. This looks like an improvement compared to neofetch's version.
