### PR TITLE
TerminalShell: fix bash version detection on Windows

### DIFF
--- a/src/detection/terminalshell/terminalshell.c
+++ b/src/detection/terminalshell/terminalshell.c
@@ -4,16 +4,14 @@
 static void getShellVersionBash(FFstrbuf* exe, FFstrbuf* version)
 {
     ffProcessAppendStdOut(version, (char* const[]) {
-        "env",
-        "-i",
         exe->chars,
-        "--norc",
-        "--noprofile",
-        "-c",
-        "printf \"%s\" \"$BASH_VERSION\"",
+        "--version",
         NULL
-    });
-    ffStrbufSubstrBeforeFirstC(version, '(');
+    }); // GNU bash, version 5.1.16(1)-release (x86_64-pc-msys)\nCopyright...
+    ffStrbufSubstrBeforeFirstC(version, '\n'); // GNU bash, version 5.1.16(1)-release (x86_64-pc-msys)
+    ffStrbufSubstrBeforeLastC(version, ' '); // GNU bash, version 5.1.16(1)-release
+    ffStrbufSubstrAfterLastC(version, ' '); // 5.1.16(1)-release
+    ffStrbufSubstrBeforeFirstC(version, '('); // 5.1.16
 }
 
 static void getShellVersionZsh(FFstrbuf* exe, FFstrbuf* version)


### PR DESCRIPTION
Currently we use `env -i /path/to/bash --norc --noprofile -c printf "%s" "$BASH_VERSION"` to detect bash version.
This is problematic on Windows because there is no `env` in $PATH ( there is env in $PATH of msys2 but not in $PATH of Windows )
With this modification the detection is also faster because 1 process is created only