### PR TITLE
Disk: add volume name detection; don't print 0B / 0B (0%)

### DIFF
--- a/presets/verbose
+++ b/presets/verbose
@@ -19,7 +19,7 @@
 --cpu-usage-format Percentage: {}
 --gpu-format Vendor: {}; Name: {}; Driver: {}; Temperature: {}; CoreCount: {}
 --memory-format Used: {}; Total: {}; Percentage: {}
---disk-format SizeUsed: {}; SizeTotal: {}; SizePercentage: {}; FilesUsed: {}; FilesTotal: {}; FilesPercentage: {}; Removable: {}; Hidden: {}; Filesystem: {}
+--disk-format SizeUsed: {}; SizeTotal: {}; SizePercentage: {}; FilesUsed: {}; FilesTotal: {}; FilesPercentage: {}; Removable: {}; Hidden: {}; Filesystem: {}; Name: {}
 --battery-format Manufactor: {}; Model: {}; Technology: {}; Capacity: {}; Status: {}
 --poweradapter-format Watts: {}; Name: {}; Manufactor: {}; Model: {}; Description: {}
 --player-format Pretty: {}; Name: {}; Bus: {}; Url: {}

--- a/src/detection/disk/disk.c
+++ b/src/detection/disk/disk.c
@@ -19,13 +19,6 @@ const FFDiskResult* ffDetectDisks()
         if(result.disks.length == 0 && result.error.length == 0)
             ffStrbufAppendS(&result.error, "No disks found");
 
-        for(uint32_t i = 0; i < result.disks.length; ++i)
-        {
-            FFDisk* disk = ffListGet(&result.disks, i);
-            disk->bytesPercentage = (uint8_t) (((long double) disk->bytesUsed / (long double) disk->bytesTotal) * 100.0);
-            disk->filesPercentage = (uint8_t) (((long double) disk->filesUsed / (long double) disk->filesTotal) * 100.0);
-        }
-
         //We need to sort the disks, so that we can detect, which disk a path resides on
         // For example for /boot/efi/bootmgr we need to check /boot/efi before /boot
         //Note that we sort alphabetically here for a better ordering when printing the list,

--- a/src/detection/disk/disk.h
+++ b/src/detection/disk/disk.h
@@ -16,6 +16,7 @@ typedef struct FFDisk
 {
     FFstrbuf mountpoint;
     FFstrbuf filesystem;
+    FFstrbuf name;
     FFDiskType type;
 
     uint64_t bytesUsed;

--- a/src/detection/disk/disk.h
+++ b/src/detection/disk/disk.h
@@ -21,11 +21,9 @@ typedef struct FFDisk
 
     uint64_t bytesUsed;
     uint64_t bytesTotal;
-    uint8_t bytesPercentage;
 
     uint32_t filesUsed;
     uint32_t filesTotal;
-    uint8_t filesPercentage;
 } FFDisk;
 
 typedef struct FFDiskResult

--- a/src/detection/disk/disk_linux.c
+++ b/src/detection/disk/disk_linux.c
@@ -72,6 +72,8 @@ void ffDetectDisksImpl(FFDiskResult* disks)
 
         disk->filesTotal = (uint32_t) fs.f_files;
         disk->filesUsed = (uint32_t) (disk->filesTotal - fs.f_ffree);
+
+        ffStrbufInit(&disk->name); //TODO: implement this
     }
 
     if(line != NULL)

--- a/src/detection/disk/disk_windows.c
+++ b/src/detection/disk/disk_windows.c
@@ -22,7 +22,7 @@ void ffDetectDisksImpl(FFDiskResult* disks)
         UINT driveType = GetDriveTypeA(mountpoint);
         if(driveType == DRIVE_NO_ROOT_DIR)
         {
-            i += strlen(mountpoint);
+            i += (uint32_t)strlen(mountpoint);
             continue;
         }
 
@@ -45,13 +45,18 @@ void ffDetectDisksImpl(FFDiskResult* disks)
             disk->type = FF_DISK_TYPE_HIDDEN;
 
         ffStrbufInitA(&disk->filesystem, MAX_PATH + 1);
+        ffStrbufInitA(&disk->name, MAX_PATH + 1);
+        //https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getvolumeinformationa#remarks
+        UINT errorMode = SetErrorMode(SEM_FAILCRITICALERRORS);
         GetVolumeInformationA(mountpoint,
-            NULL, 0, //Volume name
+            disk->name.chars, disk->name.allocated, //Volume name
             NULL, //Serial number
             NULL, //Max component length
             NULL, //File system flags
             disk->filesystem.chars, disk->filesystem.allocated
         );
+        SetErrorMode(errorMode);
+        ffStrbufRecalculateLength(&disk->name);
         ffStrbufRecalculateLength(&disk->filesystem);
 
         //TODO: implement

--- a/src/modules/disk.c
+++ b/src/modules/disk.c
@@ -4,7 +4,7 @@
 #include "detection/disk/disk.h"
 
 #define FF_DISK_MODULE_NAME "Disk"
-#define FF_DISK_NUM_FORMAT_ARGS 9
+#define FF_DISK_NUM_FORMAT_ARGS 10
 
 static void printDisk(FFinstance* instance, const FFDisk* disk)
 {
@@ -49,7 +49,8 @@ static void printDisk(FFinstance* instance, const FFDisk* disk)
             {FF_FORMAT_ARG_TYPE_UINT8, &disk->filesPercentage},
             {FF_FORMAT_ARG_TYPE_BOOL, FF_FORMAT_ARG_VALUE_BOOL(disk->type == FF_DISK_TYPE_EXTERNAL)},
             {FF_FORMAT_ARG_TYPE_BOOL, FF_FORMAT_ARG_VALUE_BOOL(disk->type == FF_DISK_TYPE_HIDDEN)},
-            {FF_FORMAT_ARG_TYPE_STRBUF, &disk->filesystem}
+            {FF_FORMAT_ARG_TYPE_STRBUF, &disk->filesystem},
+            {FF_FORMAT_ARG_TYPE_STRBUF, &disk->name}
         });
     }
 

--- a/src/modules/disk.c
+++ b/src/modules/disk.c
@@ -30,23 +30,31 @@ static void printDisk(FFinstance* instance, const FFDisk* disk)
     ffStrbufInit(&totalPretty);
     ffParseSize(disk->bytesTotal, instance->config.binaryPrefixType, &totalPretty);
 
+    uint8_t bytesPercentage = disk->bytesTotal > 0 ? (uint8_t) (((long double) disk->bytesUsed / (long double) disk->bytesTotal) * 100.0) : 0;
+
     if(instance->config.disk.outputFormat.length == 0)
     {
         ffPrintLogoAndKey(instance, key.chars, 0, NULL);
-        printf("%s / %s (%u%%)", usedPretty.chars, totalPretty.chars, disk->bytesPercentage);
+        if(disk->bytesTotal > 0)
+            printf("%s / %s (%u%%)", usedPretty.chars, totalPretty.chars, bytesPercentage);
+        else
+            fputs("unknown", stdout);
+
         if(disk->type == FF_DISK_TYPE_EXTERNAL)
             printf(" [Removable]");
         putchar('\n');
     }
     else
     {
+        uint8_t filesPercentage = disk->filesTotal > 0 ? (uint8_t) (((double) disk->filesUsed / (double) disk->filesTotal) * 100.0) : 0;
+
         ffPrintFormatString(instance, key.chars, 0, NULL, &instance->config.disk.outputFormat, FF_DISK_NUM_FORMAT_ARGS, (FFformatarg[]){
             {FF_FORMAT_ARG_TYPE_STRBUF, &usedPretty},
             {FF_FORMAT_ARG_TYPE_STRBUF, &totalPretty},
-            {FF_FORMAT_ARG_TYPE_UINT8, &disk->bytesPercentage},
+            {FF_FORMAT_ARG_TYPE_UINT8, &bytesPercentage},
             {FF_FORMAT_ARG_TYPE_UINT, &disk->filesUsed},
             {FF_FORMAT_ARG_TYPE_UINT, &disk->filesTotal},
-            {FF_FORMAT_ARG_TYPE_UINT8, &disk->filesPercentage},
+            {FF_FORMAT_ARG_TYPE_UINT8, &filesPercentage},
             {FF_FORMAT_ARG_TYPE_BOOL, FF_FORMAT_ARG_VALUE_BOOL(disk->type == FF_DISK_TYPE_EXTERNAL)},
             {FF_FORMAT_ARG_TYPE_BOOL, FF_FORMAT_ARG_VALUE_BOOL(disk->type == FF_DISK_TYPE_HIDDEN)},
             {FF_FORMAT_ARG_TYPE_STRBUF, &disk->filesystem},


### PR DESCRIPTION
Labels are commonly used on Windows and macOS

It seems that Linux also supports labels for some filesystems ( `xfs_admin -l` `e2label` ), but I don't know how to get them programmingly