### PR TITLE
Android: add vulkan support for GPU detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ include(CheckIncludeFile)
 include(CMakeDependentOption)
 
 cmake_dependent_option(ENABLE_LIBPCI "Enable libpci" ON "LINUX OR BSD" OFF)
-cmake_dependent_option(ENABLE_VULKAN "Enable vulkan" ON "LINUX OR APPLE OR BSD OR WIN32" OFF)
+cmake_dependent_option(ENABLE_VULKAN "Enable vulkan" ON "LINUX OR APPLE OR BSD OR WIN32 OR ANDROID" OFF)
 cmake_dependent_option(ENABLE_WAYLAND "Enable wayland-client" ON "LINUX OR BSD" OFF)
 cmake_dependent_option(ENABLE_XCB_RANDR "Enable xcb-randr" ON "LINUX OR BSD" OFF)
 cmake_dependent_option(ENABLE_XCB "Enable xcb" ON "LINUX OR BSD" OFF)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following libraries are used if present at runtime:
 ### macOS
 
 * [`MediaRemote`](https://iphonedev.wiki/index.php/MediaRemote.framework): Need for Media detection. It's a private framework provided by newer macOS system.
-* [`libvulkan`](https://www.vulkan.org/): Vulkan module. To get it actually working, both loader (`vulkan-loader`) and driver (molten-vk) need to be installed.
+* [`libvulkan`](https://www.vulkan.org/): Vulkan module. To get it actually working, both loader (`vulkan-loader`) and driver (`molten-vk`) need to be installed.
 
 ### Windows
 
@@ -64,6 +64,7 @@ The following libraries are used if present at runtime:
 ### Android
 
 * [`freetype`](https://www.freetype.org/): Used for Termux font detection.
+* [`libvulkan`](https://www.vulkan.org/): Vulkan module, also used for GPU detection. Usually has been provided by Android system.
 
 ## Support status
 All categories not listed here should work without needing a specific implementation.


### PR DESCRIPTION
Termux does have package pciutils, but it's put inside of root-repo and and doesn't provide libpci.pc. So I think use vulkan can be a better option than libpci because vulkan.so is provided by Android system.

To build fastfetch with android support, install `vulkan-headers` and `vulkan-loader-android` (for `vulkan.pc`). Termux package needs updating.