### PR TITLE
Add Vanilla OS logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Title, Separator, OS, Host, Bios, Board, Kernel, Uptime, Processes, Packages, Sh
 
 ##### Logos
 ```
-AlmaLinux, Alpine, Android, Arch, Arco, Artix, Bedrock, CachyOS, CentOS, Crystal, Debian, Devuan, Deepin, Endeavour, Fedora, FreeBSD, Garuda, Gentoo, KDE Neon, KISS, Kubuntu, LangitKetujuh, Linux, MacOS, Manjaro, Mint, MSYS2, NixOS, Nobara, OpenSUSE, OpenSUSE Tumbleweed, OpenSUSE LEAP, Parabola, Pop!_OS, RebornOS, RedstarOS, Rocky, Rosa, Slackware, Ubuntu, Void, Windows 11, Windows 8, Windows, Zorin
+AlmaLinux, Alpine, Android, Arch, Arco, Artix, Bedrock, CachyOS, CentOS, Crystal, Debian, Devuan, Deepin, Endeavour, Fedora, FreeBSD, Garuda, Gentoo, KDE Neon, KISS, Kubuntu, LangitKetujuh, Linux, MacOS, Manjaro, Mint, MSYS2, NixOS, Nobara, OpenSUSE, OpenSUSE Tumbleweed, OpenSUSE LEAP, Parabola, Pop!_OS, RebornOS, RedstarOS, Rocky, Rosa, Slackware, Ubuntu, Vanilla, Void, Windows 11, Windows 8, Windows, Zorin
 ```
 * Most of the logos have a small variant. Access it by appending _small to the logo name.
 * Some logos have an old variant. Access it by appending _old to the logo name.

--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -2113,6 +2113,39 @@ static const FFlogo* getLogoUbuntuSmall()
     FF_LOGO_RETURN
 }
 
+static const FFlogo* getLogoVanilla()
+{
+    
+    FF_LOGO_INIT
+    FF_LOGO_NAMES("vanilla", "vanilla-os","vanilla-linux");
+    FF_LOGO_LINES(
+"                .----: \n"
+"              .-------.\n"
+"             :---::----:\n"
+"            .----::-----.\n"
+"  .........  :----::-----: ..:::-::::..\n"
+".-----------------::------------------:\n"
+" ----::-----------::----------::::---:\n"
+"  -----:::--------::-------:::-------\n"
+"   :------::::--::...:::::---------:\n"
+"    .---------::..    ..:---------.\n"
+"      .::-----::..    .::----::.\n"
+"        .:------:.......:-------:\n"
+"       .--------::::::::-:::-------.\n"
+"      .-------::-----.:-----::------.\n"
+"     -----::------:   :------::-----\n"
+"    :--::--------:     .-------::---:\n"
+"   :----------::         .:----------\n"
+"    :--------:             :--------:"
+    )
+    FF_LOGO_COLORS(
+        "33" //yellow
+    )
+    FF_LOGO_COLOR_KEYS("33"); // yellow
+    FF_LOGO_COLOR_TITLE("33"); // yellow
+    FF_LOGO_RETURN
+}
+
 static const FFlogo* getLogoVoid()
 {
     FF_LOGO_INIT
@@ -2272,6 +2305,7 @@ GetLogoMethod* ffLogoBuiltinGetAll()
         getLogoUbuntu,
         getLogoUbuntuOld,
         getLogoUbuntuSmall,
+        getLogoVanilla,
         getLogoVoid,
         getLogoVoidSmall,
         getLogoZorin,


### PR DESCRIPTION
Adding logo for Vanilla OS a new and upcoming Ubuntu-based distribution that uses Vanilla GNOME and uses on-demand immutability.

Signed-off-by: K.B.Dharun Krishna <kbdharunkrishna@gmail.com>

**I am not sure about the colour and I am not able to replicate [this one](https://github.com/dylanaraps/neofetch/pull/2222), feel free to modify this PR.**

![image](https://user-images.githubusercontent.com/26346867/200481899-6d8e39cc-5bf7-486c-b761-b13da3410ee4.png)
