### PR TITLE
Windows / macOS: simplify code

### DIFF
--- a/src/common/networking_windows.c
+++ b/src/common/networking_windows.c
@@ -75,7 +75,7 @@ bool ffNetworkingSendHttpRequest(FFNetworkingState* state, const char* host, con
         }
     }
 
-    FFstrbuf command;
+    FF_STRBUF_AUTO_DESTROY command;
     ffStrbufInitA(&command, 64);
     ffStrbufAppendS(&command, "GET ");
     ffStrbufAppendS(&command, path);
@@ -87,7 +87,6 @@ bool ffNetworkingSendHttpRequest(FFNetworkingState* state, const char* host, con
 
     BOOL result = ConnectEx(state->sockfd, addr->ai_addr, (int)addr->ai_addrlen, command.chars, command.length, NULL, &state->overlapped);
     freeaddrinfo(addr);
-    ffStrbufDestroy(&command);
 
     if(!result && WSAGetLastError() != WSA_IO_PENDING)
     {
@@ -95,7 +94,6 @@ bool ffNetworkingSendHttpRequest(FFNetworkingState* state, const char* host, con
         return false;
     }
 
-    ffStrbufDestroy(&command);
     return true;
 }
 

--- a/src/common/processing_windows.c
+++ b/src/common/processing_windows.c
@@ -27,27 +27,30 @@ const char* ffProcessAppendStdOut(FFstrbuf* buffer, char* const argv[])
         .hStdOutput = hChildStdoutWrite,
     };
 
-    FFstrbuf cmdline;
-    ffStrbufInitF(&cmdline, "\"%s\"", argv[0]);
-    for(char* const* parg = &argv[1]; *parg; ++parg)
+    BOOL success;
+
     {
-        ffStrbufAppendC(&cmdline, ' ');
-        ffStrbufAppendS(&cmdline, *parg);
+        FF_STRBUF_AUTO_DESTROY cmdline;
+        ffStrbufInitF(&cmdline, "\"%s\"", argv[0]);
+        for(char* const* parg = &argv[1]; *parg; ++parg)
+        {
+            ffStrbufAppendC(&cmdline, ' ');
+            ffStrbufAppendS(&cmdline, *parg);
+        }
+
+        success = CreateProcessA(
+            NULL,          // application name
+            cmdline.chars, // command line
+            NULL,          // process security attributes
+            NULL,          // primary thread security attributes
+            TRUE,          // handles are inherited
+            0,             // creation flags
+            NULL,          // use parent's environment
+            NULL,          // use parent's current directory
+            &siStartInfo,  // STARTUPINFO pointer
+            &piProcInfo    // receives PROCESS_INFORMATION
+        );
     }
-
-    BOOL success = CreateProcessA(
-        NULL,          // application name
-        cmdline.chars, // command line
-        NULL,          // process security attributes
-        NULL,          // primary thread security attributes
-        TRUE,          // handles are inherited
-        0,             // creation flags
-        NULL,          // use parent's environment
-        NULL,          // use parent's current directory
-        &siStartInfo,  // STARTUPINFO pointer
-        &piProcInfo);  // receives PROCESS_INFORMATION
-
-    ffStrbufDestroy(&cmdline);
 
     CloseHandle(hChildStdoutWrite);
     if(!success)

--- a/src/detection/battery/battery_apple.c
+++ b/src/detection/battery/battery_apple.c
@@ -7,7 +7,7 @@
 
 static double detectBatteryTemp()
 {
-    FFlist temps;
+    FF_LIST_AUTO_DESTROY temps;
     ffListInit(&temps, sizeof(FFTempValue));
 
     ffDetectCoreTemps(FF_TEMP_BATTERY, &temps);
@@ -25,7 +25,6 @@ static double detectBatteryTemp()
         ffStrbufDestroy(&tempValue->deviceClass);
     }
     result /= temps.length;
-    ffListDestroy(&temps);
     return result;
 }
 

--- a/src/detection/cpu/cpu_apple.c
+++ b/src/detection/cpu/cpu_apple.c
@@ -15,7 +15,7 @@ static double getFrequency(const char* propName)
 
 static double detectCpuTemp(const FFstrbuf* cpuName)
 {
-    FFlist temps;
+    FF_LIST_AUTO_DESTROY temps;
     ffListInit(&temps, sizeof(FFTempValue));
 
     if(ffStrbufStartsWithS(cpuName, "Apple M1"))
@@ -38,7 +38,6 @@ static double detectCpuTemp(const FFstrbuf* cpuName)
         ffStrbufDestroy(&tempValue->deviceClass);
     }
     result /= temps.length;
-    ffListDestroy(&temps);
     return result;
 }
 

--- a/src/detection/font/font_windows.cpp
+++ b/src/detection/font/font_windows.cpp
@@ -18,7 +18,7 @@ void ffDetectFontImpl(const FFinstance* instance, FFFontResult* result)
 
     if(FFWmiRecord record = query.next())
     {
-        FFstrbuf fontName;
+        FF_STRBUF_AUTO_DESTROY fontName;
         ffStrbufInit(&fontName);
         record.getString(L"IconTitleFaceName", &fontName);
 
@@ -26,8 +26,6 @@ void ffDetectFontImpl(const FFinstance* instance, FFFontResult* result)
         record.getUnsigned(L"IconTitleSize", &fontSize);
 
         ffStrbufAppendF(&result->fonts[0], "%*s (%upt)", fontName.length, fontName.chars, (unsigned)fontSize);
-
-        ffStrbufDestroy(&fontName);
     }
     else
         ffStrbufInitS(&result->error, "No WMI result returned");

--- a/src/detection/gpu/gpu_apple.c
+++ b/src/detection/gpu/gpu_apple.c
@@ -8,7 +8,7 @@
 
 static double detectGpuTemp(const FFstrbuf* gpuName)
 {
-    FFlist temps;
+    FF_LIST_AUTO_DESTROY temps;
     ffListInit(&temps, sizeof(FFTempValue));
 
     if(ffStrbufStartsWithS(gpuName, "Apple M1"))
@@ -35,7 +35,6 @@ static double detectGpuTemp(const FFstrbuf* gpuName)
         ffStrbufDestroy(&tempValue->deviceClass);
     }
     result /= temps.length;
-    ffListDestroy(&temps);
     return result;
 }
 

--- a/src/detection/packages/packages_apple.c
+++ b/src/detection/packages/packages_apple.c
@@ -27,7 +27,7 @@ static uint32_t getNumElements(const char* dirname, unsigned char type)
 
 static uint32_t countBrewPackages(const char* dirname)
 {
-    FFstrbuf baseDir;
+    FF_STRBUF_AUTO_DESTROY baseDir;
     ffStrbufInitS(&baseDir, dirname);
 
     uint32_t result = 0;
@@ -41,7 +41,6 @@ static uint32_t countBrewPackages(const char* dirname)
     result += getNumElements(baseDir.chars, DT_DIR);
     ffStrbufSubstrBefore(&baseDir, baseDirLength);
 
-    ffStrbufDestroy(&baseDir);
     return result;
 }
 
@@ -59,14 +58,11 @@ static uint32_t getBrewPackages()
 
 static uint32_t countMacPortsPackages(const char* dirname)
 {
-    FFstrbuf baseDir;
+    FF_STRBUF_AUTO_DESTROY baseDir;
     ffStrbufInitS(&baseDir, dirname);
     ffStrbufAppendS(&baseDir, "/var/macports/software");
 
-    uint32_t result = getNumElements(baseDir.chars, DT_DIR);
-
-    ffStrbufDestroy(&baseDir);
-    return result;
+    return getNumElements(baseDir.chars, DT_DIR);
 }
 
 static uint32_t getMacPortsPackages()

--- a/src/detection/terminalfont/terminalfont_apple.m
+++ b/src/detection/terminalfont/terminalfont_apple.m
@@ -46,25 +46,21 @@ static void detectIterm2(const FFinstance* instance, FFTerminalFontResult* termi
 
 static void detectAppleTerminal(FFTerminalFontResult* terminalFont)
 {
-    FFstrbuf fontName;
+    FF_STRBUF_AUTO_DESTROY fontName;
     ffStrbufInit(&fontName);
     ffOsascript("tell application \"Terminal\" to font name of window frontmost", &fontName);
 
     if(fontName.length == 0)
     {
         ffStrbufAppendS(&terminalFont->error, "executing osascript failed");
-        ffStrbufDestroy(&fontName);
         return;
     }
 
-    FFstrbuf fontSize;
+    FF_STRBUF_AUTO_DESTROY fontSize;
     ffStrbufInit(&fontSize);
     ffOsascript("tell application \"Terminal\" to font size of window frontmost", &fontSize);
 
     ffFontInitValues(&terminalFont->font, fontName.chars, fontSize.chars);
-
-    ffStrbufDestroy(&fontName);
-    ffStrbufDestroy(&fontSize);
 }
 
 void ffDetectTerminalFontPlatform(const FFinstance* instance, const FFTerminalShellResult* terminalShell, FFTerminalFontResult* terminalFont)

--- a/src/util/FFlist.h
+++ b/src/util/FFlist.h
@@ -45,4 +45,8 @@ static inline void ffListSort(FFlist* list, int(*compar)(const void*, const void
     qsort(list->data, list->length, list->elementSize, compar);
 }
 
+#if defined(_WIN32) || defined(__APPLE__)
+    #define FF_LIST_AUTO_DESTROY FFlist __attribute__((__cleanup__(ffListDestroy)))
+#endif
+
 #endif

--- a/src/util/FFstrbuf.h
+++ b/src/util/FFstrbuf.h
@@ -301,4 +301,9 @@ static inline FF_C_NODISCARD bool ffStrbufEndsWithIgnCase(const FFstrbuf* strbuf
 {
     return ffStrbufEndsWithIgnCaseNS(strbuf, end->length, end->chars);
 }
+
+#if defined(_WIN32) || defined(__APPLE__)
+    #define FF_STRBUF_AUTO_DESTROY FFstrbuf __attribute__((__cleanup__(ffStrbufDestroy)))
+#endif
+
 #endif


### PR DESCRIPTION
1. simplify resource management by using C++ RAII like GCC attribute extension `cleanup`
2. simplify HEKY reading

Actually `__attribute__((__cleanup__(cleanupFn)))` is supported on all major C compiler ( gcc, clang and icc ) except MSVC I only used it on Windows and macOS for now. Let's see if the project author like it.