### PR TITLE
Add support for displaying the ISA string on RISC-V CPUs

### DIFF
--- a/src/common/printing.c
+++ b/src/common/printing.c
@@ -135,7 +135,7 @@ void ffPrintCharTimes(char c, uint32_t times)
 
     char str[32];
     memset(str, c, sizeof(str)); //2 instructions when compiling with AVX2 enabled
-    for(uint32_t i = sizeof(str); i <= times; i += sizeof(str))
+    for(uint32_t i = sizeof(str); i <= times; i += (uint32_t)sizeof(str))
         fwrite(str, 1, sizeof(str), stdout);
     uint32_t remaining = times % sizeof(str);
     if(remaining > 0)


### PR DESCRIPTION
This PR adds support for displaying the ISA string (like "rv64gc") and uarch in the CPU section on RISC-V CPUs.

I have tested this both on real hardware (Debian on StarFive VisionFive 2) and an emulator (Ubuntu on Qemu).

I noticed that FFCPUResult seems to have content that is applicable across CPUs and operating systems, so I did not add ISA and uarch there, instead I added them as extra arguments to `parseCpuInfo` like the existing `cpuMHz`. There is a new `parseIsa` method that handles parsing/prettifying the ISA string for displaying to the user. Finally, the uarch and ISA are appended to the CPU name.

On RISC-V, `/proc/cpuinfo` does not have `model name :` defined, so the old check of `cpu->name.length > 0` was causing the "Stop after the first CPU" logic to break. I don't think that this check is necessary, it should be sufficient to just check if the line we're parsing is empty, so I removed it. I have tested that this doesn't break things on an x86_64 Linux system. Also, I tested on arm64 Linux, but it doesn't work there with or without this PR (will need another PR to add support for arm64 Linux, it's out of scope for this one).

Example output on real hardware (Debian on StarFive VisionFive 2):

```
$ ./fastfetch
       _,met$$$$$gg.           user@starfive
    ,g$$$$$$$$$$$$$$$P.        -------------
  ,g$$P"         """Y$$.".     OS: Debian GNU/Linux riscv64
 ,$$P'               `$$$.     Host: StarFive VisionFive V2
',$$P       ,ggs.     `$$b:    Kernel: 5.15.0-starfive
`d$$'     ,$P"'   .    $$$     Uptime: 3 hours, 58 mins
 $$P      d$'     ,    $$$P    Packages: 1889 (dpkg)
 $$:      $.   -    ,d$$'      Shell: bash 5.1.16
 $$;      Y$b._   _,d$P'       Resolution: 3840x2160 (Brightness 0%)
 Y$$.    `.`"Y$$$$P"'          Cursor: Adwaita
 `$$b      "-.__               Terminal: /dev/pts/2
  `Y$$                         CPU: sifive,u74-mc rv64gc (4) @ 1.5 GHz
   `Y$$.                       Memory: 543.34 MiB / 7.74 GiB (6%)
     `$$b.                     Disk (/): 38.87 GiB / 89.65 GiB (43%)
       `Y$$b.                  Locale: en_US.UTF-8
          `"Y$b._    
             `"""              ████████████████████████
                               ████████████████████████
```

Example output on the emulator (Ubuntu 20.04 on Qemu):

```
$ ./fastfetch
                            ....               ubuntu@ubuntu
              .',:clooo:  .:looooo:.           -------------
           .;looooooooc  .oooooooooo'          OS: Ubuntu 20.04 riscv64
        .;looooool:,''.  :ooooooooooc          Host: riscv-virtio,qemu
       ;looool;.         'oooooooooo,          Kernel: 5.8.0-14-generic
      ;clool'             .cooooooc.  ,,       Uptime: 3 hours, 4 mins
         ...                ......  .:oo,      Packages: 760 (dpkg)
  .;clol:,.                        .loooo'     Shell: bash 5.0.17
 :ooooooooo,                        'ooool     Terminal: /dev/pts/0
'ooooooooooo.                        loooo.    CPU: rv64gch (8)
'ooooooooool                         coooo.    Memory: 168.85 MiB / 15.63 GiB (1%)
 ,loooooooc.                        .loooo.    Disk (/): 12.84 GiB / 42.01 GiB (30%)
   .,;;;'.                          ;ooooc     Locale: C.UTF-8
       ...                         ,ooool.    
    .cooooc.              ..',,'.  .cooo.      ████████████████████████
      ;ooooo:.           ;oooooooc.  :l.       ████████████████████████
       .coooooc,..      coooooooooo.    
         .:ooooooolc:. .ooooooooooo'    
           .':loooooo;  ,oooooooooc    
               ..';::c'  .;loooo:'    
                             .    
```

For comparison, here is what the output looks like in fastfetch before this PR:

<details>
Old/existing output on real hardware (Debian on StarFive VisionFive 2):

```
$ ./fastfetch
       _,met$$$$$gg.           user@starfive
    ,g$$$$$$$$$$$$$$$P.        -------------
  ,g$$P"         """Y$$.".     OS: Debian GNU/Linux riscv64
 ,$$P'               `$$$.     Host: StarFive VisionFive V2
',$$P       ,ggs.     `$$b:    Kernel: 5.15.0-starfive
`d$$'     ,$P"'   .    $$$     Uptime: 4 hours, 9 mins
 $$P      d$'     ,    $$$P    Packages: 1889 (dpkg)
 $$:      $.   -    ,d$$'      Shell: bash 5.1.16
 $$;      Y$b._   _,d$P'       Resolution: 3840x2160 (Brightness 0%)
 Y$$.    `.`"Y$$$$P"'          Cursor: Adwaita
 `$$b      "-.__               Terminal: /dev/pts/2
  `Y$$                         CPU: CPU (4) @ 1.5 GHz
   `Y$$.                       Memory: 546.09 MiB / 7.74 GiB (6%)
     `$$b.                     Disk (/): 38.87 GiB / 89.65 GiB (43%)
       `Y$$b.                  Locale: en_US.UTF-8
          `"Y$b._    
             `"""              ████████████████████████
                               ████████████████████████
```

Old/existing output on the emulator (Ubuntu 20.04 on Qemu):

```
$ ./fastfetch
                            ....               ubuntu@ubuntu
              .',:clooo:  .:looooo:.           -------------
           .;looooooooc  .oooooooooo'          OS: Ubuntu 20.04 riscv64
        .;looooool:,''.  :ooooooooooc          Host: riscv-virtio,qemu
       ;looool;.         'oooooooooo,          Kernel: 5.8.0-14-generic
      ;clool'             .cooooooc.  ,,       Uptime: 3 hours, 4 mins
         ...                ......  .:oo,      Packages: 760 (dpkg)
  .;clol:,.                        .loooo'     Shell: bash 5.0.17
 :ooooooooo,                        'ooool     Terminal: /dev/pts/0
'ooooooooooo.                        loooo.    CPU: CPU (8)
'ooooooooool                         coooo.    Memory: 168.85 MiB / 15.63 GiB (1%)
 ,loooooooc.                        .loooo.    Disk (/): 12.84 GiB / 42.01 GiB (30%)
   .,;;;'.                          ;ooooc     Locale: C.UTF-8
       ...                         ,ooool.    
    .cooooc.              ..',,'.  .cooo.      ████████████████████████
      ;ooooo:.           ;oooooooc.  :l.       ████████████████████████
       .coooooc,..      coooooooooo.    
         .:ooooooolc:. .ooooooooooo'    
           .':loooooo;  ,oooooooooc    
               ..';::c'  .;loooo:'    
                             .    
```
</details>

