### PR TITLE
fix[getNixPackagesImpl]: count line with `wc -l` instead, also fixes leak.

### DIFF
--- a/src/detection/packages/packages_linux.c
+++ b/src/detection/packages/packages_linux.c
@@ -140,7 +140,7 @@ static uint32_t getNixPackagesImpl(char* path)
     ffStrbufInitA(&command, 255);
     ffStrbufAppendS(&command, "for x in $(nix-store --query --requisites ");
     ffStrbufAppendS(&command, path);
-    ffStrbufAppendS(&command, "); do if [ -d $x ]; then echo $x ; fi ; done | cut -d- -f2- | egrep '([0-9]{1,}\\.)+[0-9]{1,}' | egrep -v '\\-doc$|\\-man$|\\-info$|\\-dev$|\\-bin$|^nixos-system-nixos-' | uniq");
+    ffStrbufAppendS(&command, "); do if [ -d $x ]; then echo $x ; fi ; done | cut -d- -f2- | egrep '([0-9]{1,}\\.)+[0-9]{1,}' | egrep -v '\\-doc$|\\-man$|\\-info$|\\-dev$|\\-bin$|^nixos-system-nixos-' | uniq | wc -l");
 
     ffProcessAppendStdOut(&output, (char* const[]) {
         "sh",
@@ -149,13 +149,12 @@ static uint32_t getNixPackagesImpl(char* path)
         NULL
     });
 
-    //Each package is a new line in the output. If at least one line is found, add 1 for the last line.
-    uint32_t result = ffStrbufCountC(&output, '\n');
-    if(result > 0)
-        result++;
+    int result = (int) strtol(output.chars, NULL, 10);
 
+    ffStrbufDestroy(&command);
     ffStrbufDestroy(&output);
-    return result;
+
+    return (uint32_t) result;
 }
 
 static uint32_t getNixPackages(FFstrbuf* baseDir, const char* dirname)


### PR DESCRIPTION
From: #195.

Also, the leak reports before the patch:

```valgrind
==45975== Memcheck, a memory error detector
==45975== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==45975== Using Valgrind-3.20.0 and LibVEX; rerun with -h for copyright info
==45975== Command: ./result/bin/fastfetch
==45975== 
==45975== 
==45975== HEAP SUMMARY:
==45975==     in use at exit: 45,525 bytes in 60 blocks
==45975==   total heap usage: 423 allocs, 363 frees, 356,371 bytes allocated
==45975== 
==45975== 255 bytes in 1 blocks are definitely lost in loss record 26 of 37
==45975==    at 0x484679B: malloc (in /nix/store/rnymfl0h7w4wd9wvdq4y64xj43pk5cbg-valgrind-3.20.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==45975==    by 0x41AA40: ffStrbufInitA (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x425805: getNixPackages (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x4259D6: getPackageCounts (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x425483: ffDetectPackagesImpl (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x40E5A3: ffDetectPackages (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x417CE3: ffPrintPackages (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x403FB3: main (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975== 
==45975== 255 bytes in 1 blocks are definitely lost in loss record 27 of 37
==45975==    at 0x484679B: malloc (in /nix/store/rnymfl0h7w4wd9wvdq4y64xj43pk5cbg-valgrind-3.20.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==45975==    by 0x41AA40: ffStrbufInitA (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x425805: getNixPackages (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x4259E9: getPackageCounts (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x425483: ffDetectPackagesImpl (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x40E5A3: ffDetectPackages (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x417CE3: ffPrintPackages (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x403FB3: main (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975== 
==45975== 255 bytes in 1 blocks are definitely lost in loss record 28 of 37
==45975==    at 0x484679B: malloc (in /nix/store/rnymfl0h7w4wd9wvdq4y64xj43pk5cbg-valgrind-3.20.0/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==45975==    by 0x41AA40: ffStrbufInitA (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x425805: getNixPackages (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x4256F9: ffDetectPackagesImpl (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x40E5A3: ffDetectPackages (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x417CE3: ffPrintPackages (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975==    by 0x403FB3: main (in /nix/store/phcyx0ifcmw1nccwaavawm1dxlhyxhfb-fastfetch-1.8.2/bin/fastfetch)
==45975== 
==45975== LEAK SUMMARY:
==45975==    definitely lost: 765 bytes in 3 blocks
==45975==    indirectly lost: 0 bytes in 0 blocks
==45975==      possibly lost: 0 bytes in 0 blocks
==45975==    still reachable: 44,760 bytes in 57 blocks
==45975==         suppressed: 0 bytes in 0 blocks
==45975== Reachable blocks (those to which a pointer was found) are not shown.
==45975== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==45975== 
==45975== For lists of detected and suppressed errors, rerun with: -s
==45975== ERROR SUMMARY: 3 errors from 3 contexts (suppressed: 0 from 0)
```
