### PR TITLE
RFC: an attempt to add a new module which can run custom shell scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ set(LIBFASTFETCH_SRC
     src/modules/cpuUsage.c
     src/modules/cursor.c
     src/modules/custom.c
+    src/modules/command.c
     src/modules/date.c
     src/modules/datetime.c
     src/modules/de.c

--- a/src/common/init.c
+++ b/src/common/init.c
@@ -348,6 +348,18 @@ static void defaultConfig(FFinstance* instance)
     ffStrbufInitA(&instance->config.playerName, 0);
 
     instance->config.percentType = 1;
+
+    ffStrbufInitS(&instance->config.commandShell,
+        #ifdef _WIN32
+        "cmd"
+        #elif defined(__FreeBSD__)
+        "csh"
+        #else
+        "bash"
+        #endif
+    );
+    ffListInit(&instance->config.commandKeys, sizeof(FFstrbuf));
+    ffListInit(&instance->config.commandTexts, sizeof(FFstrbuf));
 }
 
 void ffInitInstance(FFinstance* instance)
@@ -558,6 +570,14 @@ static void destroyConfig(FFinstance* instance)
     ffStrbufDestroy(&instance->config.weatherOutputFormat);
     ffStrbufDestroy(&instance->config.osFile);
     ffStrbufDestroy(&instance->config.playerName);
+
+    ffStrbufDestroy(&instance->config.commandShell);
+    FF_LIST_FOR_EACH(FFstrbuf, item, instance->config.commandKeys)
+        ffStrbufDestroy(item);
+    ffListDestroy(&instance->config.commandKeys);
+    FF_LIST_FOR_EACH(FFstrbuf, item, instance->config.commandTexts)
+        ffStrbufDestroy(item);
+    ffListDestroy(&instance->config.commandTexts);
 }
 
 static void destroyState(FFinstance* instance)

--- a/src/common/processing_linux.c
+++ b/src/common/processing_linux.c
@@ -31,8 +31,8 @@ const char* ffProcessAppendStdOut(FFstrbuf* buffer, char* const argv[])
     //Parent
     close(pipes[1]);
     waitpid(childPid, NULL, 0);
-    ffAppendFDBuffer(pipes[0], buffer);
+    bool ok = ffAppendFDBuffer(pipes[0], buffer);
     close(pipes[0]);
 
-    return NULL;
+    return ok ? NULL : "ffAppendFDBuffer() failed";
 }

--- a/src/data/help.txt
+++ b/src/data/help.txt
@@ -126,6 +126,9 @@ Module specific options:
     --player-name:                  The name of the player to use
     --gl <value>:                   Set the OpenGL context creation library to use. Must be auto, egl, glx or osmesa. Default is auto
     --percent-type <value>:         Set the percentage output type. 1 for percentage number, 2 for bar, 3 for both, 6 for bar only. Default is 1
+    --command-shell <str>:          Set the shell program to execute the command text. Default is cmd for Windows, csh for FreeBSD, bash for others
+    --command-key <str>:            Set the module key to display, can be specified mulitple times
+    --command-text <str>:           Set the command text to be executed, can be specified mulitple times
 
 Parsing is not case sensitive. E.g. "--lib-PCI" is equal to "--Lib-Pci"
 If a value starts with a ?, it is optional. "true" will be used if not set.

--- a/src/fastfetch.c
+++ b/src/fastfetch.c
@@ -1301,6 +1301,20 @@ static void parseOption(FFinstance* instance, FFdata* data, const char* key, con
     }
     else if(strcasecmp(key, "--percent-type") == 0)
         instance->config.percentType = optionParseUInt32(key, value);
+    else if(strcasecmp(key, "--command-shell") == 0)
+        optionParseString(key, value, &instance->config.commandShell);
+    else if(strcasecmp(key, "--command-key") == 0)
+    {
+        FFstrbuf* result = (FFstrbuf*) ffListAdd(&instance->config.commandKeys);
+        ffStrbufInit(result);
+        optionParseString(key, value, result);
+    }
+    else if(strcasecmp(key, "--command-text") == 0)
+    {
+        FFstrbuf* result = (FFstrbuf*) ffListAdd(&instance->config.commandTexts);
+        ffStrbufInit(result);
+        optionParseString(key, value, result);
+    }
 
     //////////////////
     //Unknown option//
@@ -1454,6 +1468,8 @@ static void parseStructureCommand(FFinstance* instance, FFdata* data, const char
         ffPrintOpenCL(instance);
     else if(strcasecmp(line, "users") == 0)
         ffPrintUsers(instance);
+    else if(strcasecmp(line, "command") == 0)
+        ffPrintCommand(instance);
     else
         ffPrintErrorString(instance, line, 0, NULL, NULL, "<no implementation provided>");
 }

--- a/src/fastfetch.h
+++ b/src/fastfetch.h
@@ -208,6 +208,10 @@ typedef struct FFconfig
     FFstrbuf playerName;
 
     uint32_t percentType;
+
+    FFstrbuf commandShell;
+    FFlist commandKeys;
+    FFlist commandTexts;
 } FFconfig;
 
 typedef struct FFstate
@@ -314,5 +318,6 @@ void ffPrintVulkan(FFinstance* instance);
 void ffPrintOpenGL(FFinstance* instance);
 void ffPrintOpenCL(FFinstance* instance);
 void ffPrintUsers(FFinstance* instance);
+void ffPrintCommand(FFinstance* instance);
 
 #endif

--- a/src/modules/command.c
+++ b/src/modules/command.c
@@ -1,0 +1,67 @@
+#include "fastfetch.h"
+
+#include "common/printing.h"
+#include "common/processing.h"
+#include "util/textModifier.h"
+
+#define FF_COMMAND_MODULE_NAME "Command"
+
+static void printError(FFinstance* instance, const char* key, const char* error)
+{
+    ffPrintLogoAndKey(instance, key, 0, NULL);
+
+    if(instance->config.pipe)
+        fputs(FASTFETCH_TEXT_MODIFIER_ERROR, stdout);
+
+    fputs(error, stdout);
+
+    if(!instance->config.pipe)
+        fputs(FASTFETCH_TEXT_MODIFIER_RESET, stdout);
+
+    putchar('\n');
+}
+
+void ffPrintCommand(FFinstance* instance)
+{
+    FF_STRBUF_AUTO_DESTROY key;
+    ffStrbufInit(&key);
+
+    if(!ffListShift(&instance->config.commandKeys, &key))
+        ffStrbufInitS(&key, FF_COMMAND_MODULE_NAME);
+
+    FF_STRBUF_AUTO_DESTROY text;
+    ffStrbufInit(&text);
+    if(!ffListShift(&instance->config.commandTexts, &text))
+    {
+        printError(instance, key.chars, "No command text left");
+        return;
+    }
+
+    FF_STRBUF_AUTO_DESTROY result;
+    ffStrbufInit(&result);
+    const char* error = ffProcessAppendStdOut(&result, (char* const[]){
+        instance->config.commandShell.chars,
+        #ifdef _WIN32
+        "/c",
+        #else
+        "-c",
+        #endif
+        text.chars,
+        NULL
+    });
+
+    if(error)
+    {
+        printError(instance, key.chars, error);
+        return;
+    }
+
+    if(!result.length)
+    {
+        printError(instance, key.chars, "No result printed");
+        return;
+    }
+
+    ffPrintLogoAndKey(instance, key.chars, 0, NULL);
+    puts(result.chars);
+}


### PR DESCRIPTION
Unlike other modules, `Command` module was designed to be able to be used mulitple times. A special option `--command-text` can be set multiple times; each option specifies one script to be executed.

For example:

```
$ ./fastfetch -s title:separator:os:command:command:command \
            --command-key GCC --command-text 'gcc --version | head -1 | awk \'{print $3}\'' \
            --command-key CMake --command-text 'cmake --version | head -1 | awk \'{print $3}\'' \
            --command-key PkgConfig --command-text 'pkg-config --version'
```

<img width="867" alt="image" src="https://user-images.githubusercontent.com/6134068/212388183-8fb35a63-a42a-4a61-bbbd-d2e92267970f.png">