### PR TITLE
fix: add another mutter detection for linux mint 21.1 (cinnamon)

### DIFF
--- a/src/detection/displayserver/linux/wmde.c
+++ b/src/detection/displayserver/linux/wmde.c
@@ -70,7 +70,8 @@ static void applyPrettyNameIfWM(FFDisplayServerResult* result, const char* proce
         strcasecmp(processName, "gnome-shell") == 0 ||
         strcasecmp(processName, "gnome shell") == 0 ||
         strcasecmp(processName, "gnome-session-binary") == 0 ||
-        strcasecmp(processName, "Mutter") == 0
+        strcasecmp(processName, "Mutter") == 0 ||
+        strcasecmp(processName, "Mutter (Muffin)") == 0
     ) ffStrbufSetS(&result->wmPrettyName, FF_WM_PRETTY_MUTTER);
     else if(
         strcasecmp(processName, "cinnamon-session") == 0 ||

--- a/src/detection/displayserver/linux/wmde.c
+++ b/src/detection/displayserver/linux/wmde.c
@@ -70,12 +70,12 @@ static void applyPrettyNameIfWM(FFDisplayServerResult* result, const char* proce
         strcasecmp(processName, "gnome-shell") == 0 ||
         strcasecmp(processName, "gnome shell") == 0 ||
         strcasecmp(processName, "gnome-session-binary") == 0 ||
-        strcasecmp(processName, "Mutter") == 0 ||
-        strcasecmp(processName, "Mutter (Muffin)") == 0
+        strcasecmp(processName, "Mutter") == 0
     ) ffStrbufSetS(&result->wmPrettyName, FF_WM_PRETTY_MUTTER);
     else if(
         strcasecmp(processName, "cinnamon-session") == 0 ||
-        strcasecmp(processName, "Muffin") == 0
+        strcasecmp(processName, "Muffin") == 0 ||
+        strcasecmp(processName, "Mutter (Muffin)") == 0
     ) ffStrbufSetS(&result->wmPrettyName, FF_WM_PRETTY_MUFFIN);
     else if(strcasecmp(processName, "sway") == 0)
         ffStrbufSetS(&result->wmPrettyName, FF_WM_PRETTY_SWAY);


### PR DESCRIPTION
On Linux Mint 21.1 (cinnamon) i always got "Unknown WM: Mutter (Muffin)". Just added another comparision now i'm able to get the correct WM theme.