### PR TITLE
sound_apple.c: handle `kAudioObjectPropertyElementMain` for macOS < 12

### DIFF
--- a/src/detection/sound/sound_apple.c
+++ b/src/detection/sound/sound_apple.c
@@ -2,6 +2,11 @@
 #include "util/apple/cf_helpers.h"
 
 #include <CoreAudio/CoreAudio.h>
+#include <AvailabilityMacros.h>
+
+#ifndef MAC_OS_VERSION_12_0
+#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif
 
 const char* ffDetectSound(FF_MAYBE_UNUSED const FFinstance* instance, FFlist* devices /* List of FFSoundDevice */)
 {


### PR DESCRIPTION
We were having issues with building the latest `fastfetch` on macOS < 12 at Homebrew (see Homebrew/homebrew-core#123899) due to the use of `kAudioObjectPropertyElementMain` in `sound_apple.c`. This is not present in older versions of macOS as it was renamed from `kAudioObjectPropertyElementMaster` in macOS 12.

This PR defines a macro to solve the issue on macOS < 12, and these changes have been ~inspired by~ stolen from those made in https://github.com/libsdl-org/SDL/commit/b0dc6709b9735d22b2713a7b76e5bc0892a0e5df.