### PR TITLE
Fix EndeavourOS logo again

### DIFF
--- a/src/logo/builtin.c
+++ b/src/logo/builtin.c
@@ -735,7 +735,7 @@ static const FFlogo* getLogoEndeavour()
         "$2`-////+$1ssssssssssssssssssssssssssso$3++++-\n"
         " $2`..-+$1oosssssssssssssssssssssssso$3+++++/`\n"
         "   $3./++++++++++++++++++++++++++++++/:.\n"
-        "    `:::::::::::::::::::::::::------``"
+        "  `:::::::::::::::::::::::::------``"
     )
     FF_LOGO_COLORS(
         "35", //magenta


### PR DESCRIPTION
I mostly fixed the EndeavourOS logo way back in #292 but mistakenly added two extra spaces then. I'm finally back to remove those spaces and get the logo to match neofetch's and the official graphical logo properly.