### PR TITLE
tidy bios_linux.c

### DIFF
--- a/src/detection/bios/bios_linux.c
+++ b/src/detection/bios/bios_linux.c
@@ -3,38 +3,41 @@
 
 #include <stdlib.h>
 
-static bool hostValueSet(FFstrbuf* value)
+static bool hostValueSet(const FFstrbuf* value)
 {
-    return
-        value->length > 0 &&
-        ffStrbufStartsWithIgnCaseS(value, "To be filled") != true &&
-        ffStrbufStartsWithIgnCaseS(value, "To be set") != true &&
-        ffStrbufStartsWithIgnCaseS(value, "OEM") != true &&
-        ffStrbufStartsWithIgnCaseS(value, "O.E.M.") != true &&
-        ffStrbufIgnCaseCompS(value, "None") != 0 &&
-        ffStrbufIgnCaseCompS(value, "System Product") != 0 &&
-        ffStrbufIgnCaseCompS(value, "System Product Name") != 0 &&
-        ffStrbufIgnCaseCompS(value, "System Product Version") != 0 &&
-        ffStrbufIgnCaseCompS(value, "System Name") != 0 &&
-        ffStrbufIgnCaseCompS(value, "System Version") != 0 &&
-        ffStrbufIgnCaseCompS(value, "Default string") != 0 &&
-        ffStrbufIgnCaseCompS(value, "Undefined") != 0 &&
-        ffStrbufIgnCaseCompS(value, "Not Specified") != 0 &&
-        ffStrbufIgnCaseCompS(value, "Not Applicable") != 0 &&
-        ffStrbufIgnCaseCompS(value, "INVALID") != 0 &&
-        ffStrbufIgnCaseCompS(value, "Type1ProductConfigId") != 0 &&
-        ffStrbufIgnCaseCompS(value, "All Series") != 0
-    ;
+    const char* str = value->chars;
+    const size_t length = value->length;
+
+    return (length > 0) &&
+           !(
+               ffStrbufStartsWithIgnCaseS(str, length, "To be filled") ||
+               ffStrbufStartsWithIgnCaseS(str, length, "To be set") ||
+               ffStrbufStartsWithIgnCaseS(str, length, "OEM") ||
+               ffStrbufStartsWithIgnCaseS(str, length, "O.E.M.") ||
+               ffStrbufIgnCaseCompS(str, length, "None") == 0 ||
+               ffStrbufIgnCaseCompS(str, length, "System Product") == 0 ||
+               ffStrbufIgnCaseCompS(str, length, "System Product Name") == 0 ||
+               ffStrbufIgnCaseCompS(str, length, "System Product Version") == 0 ||
+               ffStrbufIgnCaseCompS(str, length, "System Name") == 0 ||
+               ffStrbufIgnCaseCompS(str, length, "System Version") == 0 ||
+               ffStrbufIgnCaseCompS(str, length, "Default string") == 0 ||
+               ffStrbufIgnCaseCompS(str, length, "Undefined") == 0 ||
+               ffStrbufIgnCaseCompS(str, length, "Not Specified") == 0 ||
+               ffStrbufIgnCaseCompS(str, length, "Not Applicable") == 0 ||
+               ffStrbufIgnCaseCompS(str, length, "INVALID") == 0 ||
+               ffStrbufIgnCaseCompS(str, length, "Type1ProductConfigId") == 0 ||
+               ffStrbufIgnCaseCompS(str, length, "All Series") == 0
+           );
 }
 
 static void getHostValue(const char* devicesPath, const char* classPath, FFstrbuf* buffer)
 {
     ffReadFileBuffer(devicesPath, buffer);
-    if(hostValueSet(buffer))
+    if (hostValueSet(buffer))
         return;
 
     ffReadFileBuffer(classPath, buffer);
-    if(hostValueSet(buffer))
+    if (hostValueSet(buffer))
         return;
 
     ffStrbufClear(buffer);
@@ -43,16 +46,13 @@ static void getHostValue(const char* devicesPath, const char* classPath, FFstrbu
 void ffDetectBios(FFBiosResult* bios)
 {
     ffStrbufInit(&bios->error);
-
     ffStrbufInit(&bios->biosDate);
-    getHostValue("/sys/devices/virtual/dmi/id/bios_date", "/sys/class/dmi/id/bios_date", &bios->biosDate);
-
     ffStrbufInit(&bios->biosRelease);
-    getHostValue("/sys/devices/virtual/dmi/id/bios_release", "/sys/class/dmi/id/bios_release", &bios->biosRelease);
-
     ffStrbufInit(&bios->biosVendor);
-    getHostValue("/sys/devices/virtual/dmi/id/bios_vendor", "/sys/class/dmi/id/bios_vendor", &bios->biosVendor);
-
     ffStrbufInit(&bios->biosVersion);
+
+    getHostValue("/sys/devices/virtual/dmi/id/bios_date", "/sys/class/dmi/id/bios_date", &bios->biosDate);
+    getHostValue("/sys/devices/virtual/dmi/id/bios_release", "/sys/class/dmi/id/bios_release", &bios->biosRelease);
+    getHostValue("/sys/devices/virtual/dmi/id/bios_vendor", "/sys/class/dmi/id/bios_vendor", &bios->biosVendor);
     getHostValue("/sys/devices/virtual/dmi/id/bios_version", "/sys/class/dmi/id/bios_version", &bios->biosVersion);
 }


### PR DESCRIPTION
use logical negation (!) and replace the != true checks with || to be more concise and performant.